### PR TITLE
Add logger stats metrics

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -63,8 +63,9 @@ func Run(ctx context.Context) error {
 }
 
 func setupLogger(level slog.Level) {
-	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
-	slog.SetDefault(slog.New(handler))
+	h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	mh := NewMetricSlogHandler(h, metrics.LoggerStats)
+	slog.SetDefault(slog.New(mh))
 }
 
 type ManageOptions struct {

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,28 @@
+package trabbits
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type MetricSlogHandler struct {
+	slog.Handler
+	logCounter *prometheus.CounterVec
+}
+
+func NewMetricSlogHandler(base slog.Handler, logCounter *prometheus.CounterVec) slog.Handler {
+	logCounter.WithLabelValues("INFO").Add(0)
+	logCounter.WithLabelValues("WARN").Add(0)
+	logCounter.WithLabelValues("ERROR").Add(0)
+	return &MetricSlogHandler{
+		Handler:    base,
+		logCounter: logCounter,
+	}
+}
+
+func (h *MetricSlogHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.logCounter.WithLabelValues(r.Level.String()).Inc()
+	return h.Handler.Handle(ctx, r)
+}

--- a/metrics.go
+++ b/metrics.go
@@ -32,6 +32,8 @@ type Metrics struct {
 
 	ProcessedMessages *prometheus.CounterVec
 	ErroredMessages   *prometheus.CounterVec
+
+	LoggerStats *prometheus.CounterVec
 }
 
 func NewMetrics() *Metrics {
@@ -79,6 +81,11 @@ func NewMetrics() *Metrics {
 			Name: "trabbits_errored_messages",
 			Help: "Number of errored messages by method.",
 		}, []string{"method"}),
+
+		LoggerStats: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trabbits_logger_stats",
+			Help: "Number of logger stats by level.",
+		}, []string{"level"}),
 	}
 }
 
@@ -97,6 +104,8 @@ func (m *Metrics) MustRegister() {
 
 		m.ProcessedMessages,
 		m.ErroredMessages,
+
+		m.LoggerStats,
 	)
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -16,11 +16,10 @@ import (
 type Proxy struct {
 	VirtualHost string
 
-	id     string
-	conn   net.Conn
-	r      *amqp091.Reader // framer <- client
-	w      *amqp091.Writer // framer -> client
-	config *Config
+	id   string
+	conn net.Conn
+	r    *amqp091.Reader // framer <- client
+	w    *amqp091.Writer // framer -> client
 
 	mu sync.Mutex
 
@@ -30,8 +29,6 @@ type Proxy struct {
 	user        string
 	password    string
 	clientProps amqp091.Table
-
-	keyPatterns []string
 }
 
 func NewProxy(conn net.Conn) *Proxy {


### PR DESCRIPTION
This pull request introduces a new logging handler that integrates Prometheus metrics, updates the metrics system to include logger statistics, and removes unused fields from the `Proxy` struct. Below are the most important changes grouped by theme.

### Logging Enhancements:
* Introduced a new `MetricSlogHandler` in `logger.go` to wrap the base `slog.Handler` and increment Prometheus counters based on log levels (INFO, WARN, ERROR) whenever a log is handled. (`logger.go`, [logger.goR1-R28](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eR1-R28))
* Updated the `setupLogger` function in `cli.go` to use the new `MetricSlogHandler` for logging, enabling integration with Prometheus metrics. (`cli.go`, [cli.goL66-R68](diffhunk://#diff-8d9ca23280f24fe6444d03ae46e7a15dd152170f32f57f978dfbdfd3cfe8ff55L66-R68))

### Metrics System Updates:
* Added a new `LoggerStats` field to the `Metrics` struct in `metrics.go` to track the number of log entries by level. (`metrics.go`, [metrics.goR35-R36](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R35-R36))
* Updated the `NewMetrics` function to initialize the `LoggerStats` counter with Prometheus. (`metrics.go`, [metrics.goR84-R88](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R84-R88))
* Modified the `MustRegister` method to include the `LoggerStats` counter for registration with Prometheus. (`metrics.go`, [metrics.goR107-R108](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R107-R108))

### Code Simplification:
* Removed unused fields (`config` and `keyPatterns`) from the `Proxy` struct in `proxy.go`, simplifying the struct definition. (`proxy.go`, [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L23) [[2]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L33-L34)Measure stats of slog calling by level.