### PR TITLE
Implement server-side diff API endpoint and refactor config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,12 +369,13 @@ trabbits cli also supports the configuration management. You can use `trabbits m
 the configuration. The cli access to the API server on the localhost.
 
 ```
-Usage: trabbits manage config <command>
+Usage: trabbits manage config <command> [<file>]
 
 Manage the configuration.
 
 Arguments:
   <command>    Command to run (get, diff, put).
+  <file>       Configuration file (required for diff/put commands).
 ```
 
 #### Use curl to access the API server
@@ -419,7 +420,7 @@ trabbits will reload the configuration and apply the new configuration.
 You can also use the `trabbits` cli to update the configuration.
 
 ```console
-$ trabbits manage config put --config new_config.json
+$ trabbits manage config put new_config.json
 ```
 
 #### Diff the configuration
@@ -427,7 +428,7 @@ $ trabbits manage config put --config new_config.json
 You can diff the current configuration and a new configuration using trabbits cli.
 
 ```console
-$ trabbits manage config diff --config new_config.json
+$ trabbits manage config diff new_config.json
 ```
 ```diff
 --- http://localhost:16692/config

--- a/api_test.go
+++ b/api_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,5 +113,188 @@ func TestAPIPutInvalidConfig(t *testing.T) {
 	}
 	if code := resp.StatusCode; code != http.StatusBadRequest {
 		t.Errorf("handler returned wrong status code: got %v want %v", code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIPutRawJSONConfig(t *testing.T) {
+	endpoint := "http://localhost/config"
+	client := newUnixSockHTTPClient(testAPISock)
+
+	// Test raw JSON config with environment variables
+	t.Setenv("TEST_API_USERNAME", "apiuser")
+	t.Setenv("TEST_API_PASSWORD", "apipass")
+
+	// Raw JSON config content (as it would be in a file)
+	rawConfigJSON := `{
+		"upstreams": [
+			{
+				"name": "primary",
+				"address": "localhost:5672",
+				"routing": {}
+			},
+			{
+				"name": "test-upstream",
+				"cluster": {
+					"nodes": [
+						"localhost:5673"
+					]
+				},
+				"health_check": {
+					"interval": "30s",
+					"timeout": "5s",
+					"unhealthy_threshold": 3,
+					"recovery_interval": "60s",
+					"username": "${TEST_API_USERNAME}",
+					"password": "${TEST_API_PASSWORD}"
+				},
+				"routing": {
+					"key_patterns": [
+						"test.api.*"
+					]
+				}
+			}
+		]
+	}`
+
+	// Send raw JSON content (simulating what the new putConfigFromFile does)
+	req, _ := http.NewRequest(http.MethodPut, endpoint, strings.NewReader(rawConfigJSON))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if code := resp.StatusCode; code != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", code, http.StatusOK)
+	}
+
+	// Verify the config was properly processed on server side
+	var respondConfig trabbits.Config
+	if err := json.NewDecoder(resp.Body).Decode(&respondConfig); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	// Check that environment variables were expanded on server side
+	if len(respondConfig.Upstreams) != 2 {
+		t.Fatalf("Expected 2 upstreams, got %d", len(respondConfig.Upstreams))
+	}
+
+	testUpstream := respondConfig.Upstreams[1]
+	if testUpstream.HealthCheck == nil {
+		t.Fatal("Expected health check configuration, got nil")
+	}
+
+	// Environment variables should be expanded on server side
+	if testUpstream.HealthCheck.Username != "apiuser" {
+		t.Errorf("Expected username 'apiuser', got '%s'", testUpstream.HealthCheck.Username)
+	}
+
+	// Password should be masked in response (but internally correct)
+	// The actual password is set correctly on server side but masked in JSON response
+}
+
+func TestAPIPutJsonnetConfig(t *testing.T) {
+	endpoint := "http://localhost/config"
+	client := newUnixSockHTTPClient(testAPISock)
+
+	// Test Jsonnet config
+	t.Setenv("TEST_JSONNET_USERNAME", "jsonnetuser")
+	t.Setenv("TEST_JSONNET_PASSWORD", "jsonnetpass")
+
+	// Raw Jsonnet config content
+	rawConfigJsonnet := `
+local env = std.native('env');
+{
+  upstreams: [
+    {
+      name: 'primary',
+      address: 'localhost:5672',
+      routing: {},
+    },
+    {
+      name: 'jsonnet-upstream',
+      cluster: {
+        nodes: [
+          'localhost:5674',
+        ],
+      },
+      health_check: {
+        interval: '45s',
+        timeout: '10s',
+        unhealthy_threshold: 2,
+        recovery_interval: '90s',
+        username: env('TEST_JSONNET_USERNAME', 'default'),
+        password: env('TEST_JSONNET_PASSWORD', 'default'),
+      },
+      routing: {
+        key_patterns: [
+          'jsonnet.test.*',
+        ],
+      },
+    },
+  ],
+}`
+
+	// Create temporary Jsonnet file to simulate file-based config
+	tmpfile, err := os.CreateTemp("", "test-api-config-*.jsonnet")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(rawConfigJsonnet)); err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+	tmpfile.Close()
+
+	// Read the file content back (simulating what putConfigFromFile does)
+	data, err := os.ReadFile(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("Failed to read temp file: %v", err)
+	}
+
+	// Send raw Jsonnet content with appropriate Content-Type
+	req, _ := http.NewRequest(http.MethodPut, endpoint, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/jsonnet")
+
+	// Debug: check what we're sending
+	t.Logf("Sending request with Content-Type: %s", req.Header.Get("Content-Type"))
+	t.Logf("Request body length: %d", len(data))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if code := resp.StatusCode; code != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", code, http.StatusOK)
+	}
+
+	// Verify the Jsonnet config was properly processed on server side
+	var respondConfig trabbits.Config
+	if err := json.NewDecoder(resp.Body).Decode(&respondConfig); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	// Check that Jsonnet was evaluated and environment variables were accessed
+	if len(respondConfig.Upstreams) != 2 {
+		t.Fatalf("Expected 2 upstreams, got %d", len(respondConfig.Upstreams))
+	}
+
+	jsonnetUpstream := respondConfig.Upstreams[1]
+	if jsonnetUpstream.Name != "jsonnet-upstream" {
+		t.Errorf("Expected upstream name 'jsonnet-upstream', got '%s'", jsonnetUpstream.Name)
+	}
+
+	if jsonnetUpstream.HealthCheck == nil {
+		t.Fatal("Expected health check configuration, got nil")
+	}
+
+	// Environment variables should be accessed through std.native('env') on server side
+	if jsonnetUpstream.HealthCheck.Username != "jsonnetuser" {
+		t.Errorf("Expected username 'jsonnetuser', got '%s'", jsonnetUpstream.HealthCheck.Username)
 	}
 }

--- a/cli.go
+++ b/cli.go
@@ -71,5 +71,6 @@ func setupLogger(level slog.Level) {
 type ManageOptions struct {
 	Config struct {
 		Command string `arg:"" enum:"get,diff,put" help:"Command to run (get, diff, put)."`
+		File    string `arg:"" optional:"" help:"Configuration file (required for diff/put commands)."`
 	} `cmd:"" help:"Manage the configuration."`
 }

--- a/cli.go
+++ b/cli.go
@@ -54,7 +54,7 @@ func Run(ctx context.Context) error {
 	case "run":
 		// Run the server
 		return run(ctx, &cli)
-	case "manage config <command>":
+	case "manage config <command> <file>":
 		// Manage the server
 		return manageConfig(ctx, &cli)
 	default:

--- a/manage.go
+++ b/manage.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -39,7 +40,11 @@ func manageConfigGet(ctx context.Context, opt *CLI) error {
 }
 
 func manageConfigDiff(ctx context.Context, opt *CLI) error {
-	newCfg, err := LoadConfig(ctx, opt.Config)
+	if opt.Manage.Config.File == "" {
+		return fmt.Errorf("configuration file is required for diff command")
+	}
+
+	newCfg, err := LoadConfig(ctx, opt.Manage.Config.File)
 	if err != nil {
 		return err
 	}
@@ -64,12 +69,12 @@ func manageConfigDiff(ctx context.Context, opt *CLI) error {
 }
 
 func manageConfigPut(ctx context.Context, opt *CLI) error {
-	client := newAPIClient(opt.APISocket)
-	newCfg, err := LoadConfig(ctx, opt.Config)
-	if err != nil {
-		return err
+	if opt.Manage.Config.File == "" {
+		return fmt.Errorf("configuration file is required for put command")
 	}
-	return client.putConfig(ctx, newCfg)
+
+	client := newAPIClient(opt.APISocket)
+	return client.putConfigFromFile(ctx, opt.Manage.Config.File)
 }
 
 func coloredDiff(src string) string {
@@ -124,6 +129,31 @@ func (c *apiClient) getConfig(ctx context.Context) (*Config, error) {
 	return &cfg, nil
 }
 
+func (c *apiClient) putConfigFromFile(ctx context.Context, configPath string) error {
+	slog.Info("putting config from file", "file", configPath)
+
+	// Read raw file content without any processing
+	// Let the server handle environment variable expansion and Jsonnet evaluation
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, c.endpoint, bytes.NewReader(data))
+	req.Header.Set("Content-Type", APIContentType)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to put config: %s", resp.Status)
+	}
+	slog.Info("config updated successfully")
+	return nil
+}
+
+// Keep the old method for backward compatibility, though it's not used anymore
 func (c *apiClient) putConfig(ctx context.Context, cfg *Config) error {
 	slog.Info("putting config", "config", cfg)
 	b := new(bytes.Buffer)

--- a/server_test.go
+++ b/server_test.go
@@ -198,7 +198,7 @@ func TestProxyPublishAutoQueueNaming(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		time.Sleep(100 * time.Millisecond) // Wait for the message to be delivered
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer cancel()
 		d, err := ch.ConsumeWithContext(ctx, q.Name, "", false, false, false, false, nil)
 		if err != nil {
@@ -456,7 +456,7 @@ func TestProxyQos(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 			defer cancel()
 			d, err := ch.ConsumeWithContext(ctx, qName, "", false, false, false, false, nil)
 			if err != nil {


### PR DESCRIPTION
## Summary
This PR fixes fundamental issues in the management API configuration handling and adds new server-side diff functionality.

### First commit: Fix management API config handling
- Fix password corruption in config updates due to JSON masking during round-trips
- Implement server-side environment variable expansion for consistent processing
- Add Jsonnet configuration file support via LoadConfig
- Update CLI to use file-based config transmission instead of processed structs
- Breaking change: CLI commands now use positional file arguments

### Second commit: Implement server-side diff API endpoint and refactor config handling
- Add POST /config/diff endpoint for server-side configuration diffing
- Support both JSON and Jsonnet content types via Content-Type header
- Refactor duplicated content type detection and file handling logic
- Define constants APIContentType and APIContentTypeJsonnet
- Add comprehensive tests for diff functionality
- Extract common functions to reduce code duplication

## Test plan
- [x] All existing API tests pass
- [x] New diff endpoint tests for both JSON and Jsonnet
- [x] Environment variable expansion works correctly
- [x] Password masking no longer corrupts configurations
- [x] CLI commands work with new positional argument structure

🤖 Generated with [Claude Code](https://claude.ai/code)