### PR TITLE
Add SIGHUP signal handling for configuration reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,15 @@ This command reloads the configuration from the file specified by `--config` opt
 
 You can also reload the configuration by sending a SIGHUP signal to the trabbits process.
 
+For better reliability, use a PID file to ensure you target the correct process:
+
+```console
+$ trabbits run --pid-file /var/run/trabbits.pid --config config.json
+$ kill -HUP $(cat /var/run/trabbits.pid)
+```
+
+Alternatively, you can use process discovery (less reliable):
+
 ```console
 $ kill -HUP $(pidof trabbits)
 ```

--- a/README.md
+++ b/README.md
@@ -440,6 +440,22 @@ $ trabbits manage config reload
 ```
 
 This command reloads the configuration from the file specified by `--config` option (default: `config.json`).
+
+#### Reload configuration with SIGHUP
+
+You can also reload the configuration by sending a SIGHUP signal to the trabbits process.
+
+```console
+$ kill -HUP $(pidof trabbits)
+```
+
+or
+
+```console
+$ pkill -HUP trabbits
+```
+
+This will reload the configuration from the original configuration file specified when trabbits was started.
 ```diff
 --- http://localhost:16692/config
 +++ new_config.json

--- a/cli.go
+++ b/cli.go
@@ -30,6 +30,7 @@ type CLI struct {
 }
 
 type RunOptions struct {
+	PidFile string `help:"Path to write the process ID file." env:"TRABBITS_PID_FILE"`
 }
 
 func Run(ctx context.Context) error {

--- a/cmd/trabbits/main.go
+++ b/cmd/trabbits/main.go
@@ -10,8 +10,18 @@ import (
 )
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), signals()...)
-	defer stop()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Setup signal handling with logging
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, signals()...)
+
+	go func() {
+		sig := <-sigChan
+		slog.Info("Received signal, shutting down", "signal", sig)
+		cancel()
+	}()
+
 	if err := run(ctx); err != nil {
 		slog.Error("failed to run", "error", err)
 		os.Exit(1)

--- a/export_test.go
+++ b/export_test.go
@@ -7,16 +7,17 @@ import (
 )
 
 var (
-	Boot               = boot
-	SetupLogger        = setupLogger
-	NewDelivery        = newDelivery
-	RestoreDeliveryTag = restoreDeliveryTag
-	MatchPattern       = matchPattern
-	StoreConfig        = storeConfig
-	MustGetConfig      = mustGetConfig
-	MetricsStore       = metrics
-	RunAPIServer       = runAPIServer
-	NewAPIClient       = newAPIClient
+	Boot                 = boot
+	SetupLogger          = setupLogger
+	NewDelivery          = newDelivery
+	RestoreDeliveryTag   = restoreDeliveryTag
+	MatchPattern         = matchPattern
+	StoreConfig          = storeConfig
+	MustGetConfig        = mustGetConfig
+	MetricsStore         = metrics
+	RunAPIServer         = runAPIServer
+	NewAPIClient         = newAPIClient
+	ReloadConfigFromFile = reloadConfigFromFile
 )
 
 type Delivery = delivery

--- a/sighup_test.go
+++ b/sighup_test.go
@@ -1,0 +1,100 @@
+package trabbits_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/fujiwara/trabbits"
+)
+
+// TestSIGHUPHandler tests that the SIGHUP signal properly triggers configuration reload
+func TestSIGHUPHandler(t *testing.T) {
+	// Skip this test in CI environments or if running in parallel
+	if testing.Short() {
+		t.Skip("Skipping SIGHUP test in short mode")
+	}
+
+	// Create a temporary config file
+	originalConfig := `{
+		"upstreams": [
+			{
+				"name": "primary",
+				"address": "localhost:5672",
+				"routing": {}
+			}
+		]
+	}`
+
+	tmpfile, err := os.CreateTemp("", "trabbits-sighup-test-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp config file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(originalConfig)); err != nil {
+		t.Fatalf("Failed to write temp config file: %v", err)
+	}
+	tmpfile.Close()
+
+	// Test the reload function directly
+	ctx := context.Background()
+	cfg, err := trabbits.LoadConfig(ctx, tmpfile.Name())
+	if err != nil {
+		t.Fatalf("Failed to load initial config: %v", err)
+	}
+
+	if len(cfg.Upstreams) != 1 || cfg.Upstreams[0].Name != "primary" {
+		t.Fatalf("Unexpected initial config: %+v", cfg)
+	}
+
+	// Update the config file
+	updatedConfig := `{
+		"upstreams": [
+			{
+				"name": "primary",
+				"address": "localhost:5672",
+				"routing": {}
+			},
+			{
+				"name": "sighup-added",
+				"address": "localhost:5673",
+				"routing": {
+					"key_patterns": ["sighup.test.*"]
+				}
+			}
+		]
+	}`
+
+	if err := os.WriteFile(tmpfile.Name(), []byte(updatedConfig), 0644); err != nil {
+		t.Fatalf("Failed to update config file: %v", err)
+	}
+
+	// Test that reloadConfigFromFile works correctly
+	reloadedCfg, err := trabbits.ReloadConfigFromFile(ctx, tmpfile.Name())
+	if err != nil {
+		t.Fatalf("Failed to reload config: %v", err)
+	}
+
+	if len(reloadedCfg.Upstreams) != 2 {
+		t.Fatalf("Expected 2 upstreams after reload, got %d", len(reloadedCfg.Upstreams))
+	}
+
+	foundSighupAdded := false
+	for _, upstream := range reloadedCfg.Upstreams {
+		if upstream.Name == "sighup-added" {
+			foundSighupAdded = true
+			if len(upstream.Routing.KeyPatterns) != 1 || upstream.Routing.KeyPatterns[0] != "sighup.test.*" {
+				t.Errorf("Unexpected routing patterns for sighup-added upstream: %v", upstream.Routing.KeyPatterns)
+			}
+			break
+		}
+	}
+
+	if !foundSighupAdded {
+		t.Error("Expected to find 'sighup-added' upstream after reload")
+	}
+
+	slog.Info("SIGHUP reload functionality test completed successfully")
+}


### PR DESCRIPTION
## Summary
- Add SIGHUP signal handler for configuration reload
- Extract reload logic to shared function for reuse
- Add test coverage for reload functionality
- Add --pid-file option for reliable process targeting
- Add signal logging for better observability

## Changes
- Extracted `reloadConfigFromFile` function from API handler for shared use
- Added SIGHUP signal handler in `run` function to listen for reload signals
- Added `TestSIGHUPHandler` test to verify reload functionality
- Added `--pid-file` option to write process ID for reliable signal targeting
- Added signal logging for SIGTERM/SIGINT shutdown events
- Updated README with SIGHUP reload documentation and PID file usage

## Usage
Configuration can now be reloaded in multiple ways:

1. Using the CLI command:
   ```bash
   ./trabbits manage config reload
   ```

2. Using SIGHUP signal with PID file (recommended):
   ```bash
   ./trabbits run --pid-file /var/run/trabbits.pid --config config.json
   kill -HUP $(cat /var/run/trabbits.pid)
   ```

3. Using SIGHUP signal with process discovery:
   ```bash
   kill -HUP $(pidof trabbits)
   # or
   pkill -HUP trabbits
   ```

All methods reload the configuration from the original file specified by the `--config` option. The PID file approach provides the most reliable way to target the correct process, avoiding issues when multiple trabbits processes (e.g., `trabbits manage`) are running.

🤖 Generated with [Claude Code](https://claude.ai/code)