### PR TITLE
Add % wildcard support for substring pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,10 +511,16 @@ $ echo $?
 1
 ```
 
-Pattern matching follows RabbitMQ's topic exchange rules:
+Pattern matching follows RabbitMQ's topic exchange rules with extensions:
 - `*` (star) matches exactly one word
-- `#` (hash) matches zero or more words
+- `#` (hash) matches zero or more words  
+- `%` (percent) matches zero or more characters within a single word (substring matching)
 - Words are delimited by dots (`.`)
+
+Examples with `%` wildcard:
+- `app.%service` matches `app.webservice`, `app.apiservice`, `app.service`
+- `foo.*.a%` matches `foo.xxx.aaa`, `foo.yyy.app` 
+- `%.server.*` matches `web.server.01`, `api.server.prod`
 
 ## Support for multiple instances
 


### PR DESCRIPTION
Extend routing pattern matching to support % wildcard for substring matching within individual tokens, while maintaining compatibility with existing * and # wildcards.

Features:
- % matches zero or more characters within a single token
- Works in combination with * and # wildcards
- Token-level processing maintains dot separation semantics
- SQL LIKE-style substring matching behavior

Examples:
- app.%service matches app.webservice, app.apiservice, app.service
- foo.*.a% matches foo.xxx.aaa, foo.yyy.app
- %.server.* matches web.server.01, api.server.prod

🤖 Generated with [Claude Code](https://claude.ai/code)