### PR TITLE
Add panic recovery with Prometheus metrics for enhanced stability

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -69,7 +69,7 @@ func Run(ctx context.Context) error {
 
 func setupLogger(level slog.Level) {
 	h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})
-	mh := NewMetricSlogHandler(h, metrics.LoggerStats)
+	mh := NewMetricSlogHandler(h, GetMetrics().LoggerStats)
 	slog.SetDefault(slog.New(mh))
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -17,6 +17,7 @@ var (
 	MetricsStore       = metrics
 	NewAPIClient       = newAPIClient
 	TestMatchRouting   = testMatchRouting
+	RecoverFromPanic   = recoverFromPanic
 )
 
 // Server instance functions for testing

--- a/methods.go
+++ b/methods.go
@@ -155,6 +155,7 @@ func (p *Proxy) replyBasicConsume(ctx context.Context, f *amqp091.MethodFrame, m
 		d := d
 		wg.Add(1)
 		go func() {
+			defer recoverFromPanic(p.logger, "consume.goroutine")
 			defer wg.Done()
 			p.consume(ctx, id, q, tag, d)
 		}()

--- a/panic_recovery_test.go
+++ b/panic_recovery_test.go
@@ -1,0 +1,150 @@
+package trabbits_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/fujiwara/trabbits"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecoverFromPanic(t *testing.T) {
+	// Create a buffer to capture log output
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Use the global metrics instance with sync.Once initialization
+	metrics := trabbits.GetMetrics()
+
+	functionName := "test_function"
+	panicMessage := "test panic message"
+
+	// Get initial metric value
+	initialCount := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(functionName))
+
+	// Test panic recovery
+	func() {
+		defer trabbits.RecoverFromPanic(logger, functionName)
+		panic(panicMessage)
+	}()
+
+	// Verify metric was incremented
+	finalCount := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(functionName))
+	expectedCount := initialCount + 1
+
+	if finalCount != expectedCount {
+		t.Errorf("Expected panic recovery metric to be %f, got %f", expectedCount, finalCount)
+	}
+
+	// Verify log output contains expected information
+	logOutput := logBuf.String()
+
+	if !strings.Contains(logOutput, "panic recovered") {
+		t.Error("Log output should contain 'panic recovered'")
+	}
+
+	if !strings.Contains(logOutput, functionName) {
+		t.Errorf("Log output should contain function name '%s'", functionName)
+	}
+
+	if !strings.Contains(logOutput, panicMessage) {
+		t.Errorf("Log output should contain panic message '%s'", panicMessage)
+	}
+
+	if !strings.Contains(logOutput, "stack") {
+		t.Error("Log output should contain stack trace")
+	}
+}
+
+func TestRecoverFromPanicNoPanic(t *testing.T) {
+	// Create a buffer to capture log output
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Use the global metrics instance with sync.Once initialization
+	metrics := trabbits.GetMetrics()
+
+	functionName := "test_function_no_panic"
+
+	// Get initial metric value
+	initialCount := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(functionName))
+
+	// Test normal execution (no panic)
+	func() {
+		defer trabbits.RecoverFromPanic(logger, functionName)
+		// Normal execution, no panic
+	}()
+
+	// Verify metric was NOT incremented
+	finalCount := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(functionName))
+
+	if finalCount != initialCount {
+		t.Errorf("Expected panic recovery metric to remain %f, got %f", initialCount, finalCount)
+	}
+
+	// Verify no panic-related log output
+	logOutput := logBuf.String()
+
+	if strings.Contains(logOutput, "panic recovered") {
+		t.Error("Log output should not contain 'panic recovered' when no panic occurs")
+	}
+}
+
+func TestRecoverFromPanicDifferentFunctions(t *testing.T) {
+	// Create a buffer to capture log output
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Use the global metrics instance with sync.Once initialization
+	metrics := trabbits.GetMetrics()
+
+	function1 := "handleConnection"
+	function2 := "runHeartbeat"
+
+	// Get initial metric values
+	initialCount1 := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(function1))
+	initialCount2 := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(function2))
+
+	// Test panic in function1
+	func() {
+		defer trabbits.RecoverFromPanic(logger, function1)
+		panic("panic in function1")
+	}()
+
+	// Test panic in function2
+	func() {
+		defer trabbits.RecoverFromPanic(logger, function2)
+		panic("panic in function2")
+	}()
+
+	// Verify metrics were incremented correctly for each function
+	finalCount1 := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(function1))
+	finalCount2 := testutil.ToFloat64(metrics.PanicRecoveries.WithLabelValues(function2))
+
+	if finalCount1 != initialCount1+1 {
+		t.Errorf("Expected %s metric to be %f, got %f", function1, initialCount1+1, finalCount1)
+	}
+
+	if finalCount2 != initialCount2+1 {
+		t.Errorf("Expected %s metric to be %f, got %f", function2, initialCount2+1, finalCount2)
+	}
+
+	// Verify both function names appear in logs
+	logOutput := logBuf.String()
+
+	if !strings.Contains(logOutput, function1) {
+		t.Errorf("Log output should contain function name '%s'", function1)
+	}
+
+	if !strings.Contains(logOutput, function2) {
+		t.Errorf("Log output should contain function name '%s'", function2)
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -142,6 +142,8 @@ func (p *Proxy) ClientBanner() string {
 
 // MonitorUpstreamConnection monitors an upstream connection and notifies when it closes
 func (p *Proxy) MonitorUpstreamConnection(ctx context.Context, upstream *Upstream) {
+	defer recoverFromPanic(p.logger, "MonitorUpstreamConnection")
+
 	select {
 	case <-ctx.Done():
 		p.logger.Debug("Upstream monitoring stopped by context", "upstream", upstream.String())

--- a/upstream.go
+++ b/upstream.go
@@ -45,8 +45,8 @@ func NewUpstream(conn *rabbitmq.Connection, logger *slog.Logger, conf config.Ups
 	if conn != nil {
 		conn.NotifyClose(u.closeChan)
 	}
-	metrics.UpstreamTotalConnections.WithLabelValues(address).Inc()
-	metrics.UpstreamConnections.WithLabelValues(address).Inc()
+	GetMetrics().UpstreamTotalConnections.WithLabelValues(address).Inc()
+	GetMetrics().UpstreamConnections.WithLabelValues(address).Inc()
 	return u
 }
 
@@ -80,7 +80,7 @@ func (u *Upstream) Close() error {
 	}
 
 	if u.conn != nil {
-		metrics.UpstreamConnections.WithLabelValues(u.address).Dec()
+		GetMetrics().UpstreamConnections.WithLabelValues(u.address).Dec()
 		if err := u.conn.Close(); err != nil {
 			return fmt.Errorf("failed to close connection: %w", err)
 		}


### PR DESCRIPTION
## Summary
- Add panic recovery mechanism to prevent individual client panics from crashing the entire server
- Implement Prometheus metrics `trabbits_panic_recoveries_total{function}` for monitoring panic occurrences
- Replace `init()` with `sync.Once` pattern for reliable metrics initialization across test packages

## Changes
### Core Features
- **Panic Recovery Function**: `recoverFromPanic()` with structured logging and stack traces
- **Prometheus Metrics**: Track panic count by function name for observability
- **Goroutine Protection**: Applied to critical goroutines:
  - `handleConnection`: client connection processing
  - `runHeartbeat`: heartbeat transmission  
  - `MonitorUpstreamConnection`: upstream monitoring
  - `DisconnectOutdatedProxies.worker`: proxy disconnection workers
  - `consume.goroutine`: message consumption
  - `health.monitor`: health check monitoring

### Infrastructure Improvements  
- **Reliable Initialization**: `sync.Once` pattern ensures metrics work in test packages
- **Consistent API**: All metrics access through `GetMetrics()` function
- **Comprehensive Testing**: Unit tests for panic recovery scenarios

## Test Plan
- [x] Unit tests for panic recovery functionality (3 test scenarios)
- [x] Verify metrics are correctly incremented on panic
- [x] Confirm server stability when individual goroutines panic
- [x] Test metrics initialization across different package contexts

## Observability
Monitor panic occurrences with:
```promql
# Total panics by function
trabbits_panic_recoveries_total

# Panic rate per function
rate(trabbits_panic_recoveries_total[5m])
```

🤖 Generated with [Claude Code](https://claude.ai/code)