### PR TITLE
Add comprehensive clients management API with statistics tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,8 @@ Manage connected clients.
 
 Commands:
   list                     Get connected clients information
-  shutdown <client-id>     Shutdown a specific client
+  info <proxy-id>          Get detailed information for a specific proxy
+  shutdown <proxy-id>      Shutdown a specific proxy
 ```
 
 #### Configuration Versioning and Graceful Disconnection
@@ -564,6 +565,61 @@ You can also use the `trabbits` CLI to get clients information:
 ```console
 $ trabbits manage clients list
 ```
+
+#### Get detailed client information
+
+You can get comprehensive information about a specific client by sending a GET request to the `/clients/{proxy_id}` endpoint.
+
+```console
+$ curl --unix-socket /tmp/trabbits.sock http://localhost/clients/proxy-12345678
+```
+
+This returns complete client information including:
+
+```json
+{
+  "id": "proxy-12345678",
+  "client_address": "127.0.0.1:54321",
+  "user": "admin",
+  "virtual_host": "/",
+  "client_banner": "golang/golang/AMQP 0.9.1 Client/1.10.0",
+  "client_properties": {
+    "product": "my-app",
+    "version": "1.0.0",
+    "capabilities": {
+      "publisher_confirms": true,
+      "consumer_cancel_notify": true
+    }
+  },
+  "connected_at": "2023-11-20T10:30:00Z",
+  "status": "active",
+  "stats": {
+    "started_at": "2023-11-20T10:30:00Z",
+    "methods": {
+      "Basic.Publish": 150,
+      "Basic.Consume": 5,
+      "Queue.Declare": 3
+    },
+    "total_methods": 158,
+    "received_frames": 320,
+    "sent_frames": 285,
+    "total_frames": 605,
+    "duration": "45m30s"
+  }
+}
+```
+
+Using the CLI:
+
+```console
+$ trabbits manage clients info proxy-12345678
+```
+
+The response includes:
+- Complete client properties and capabilities
+- Detailed statistics with method-level breakdown
+- Frame counters (received/sent frames)
+- Connection duration and timestamps
 
 #### Shutdown a specific proxy
 

--- a/README.md
+++ b/README.md
@@ -422,12 +422,16 @@ Arguments:
   <file>       Configuration file (required for diff/put commands).
 ```
 
-You can also get information about connected clients using the `trabbits manage clients` command:
+You can also manage connected clients using the `trabbits manage clients` command:
 
 ```
-Usage: trabbits manage clients
+Usage: trabbits manage clients <command>
 
-Get connected clients information.
+Manage connected clients.
+
+Commands:
+  list                     Get connected clients information
+  shutdown <client-id>     Shutdown a specific client
 ```
 
 #### Configuration Versioning and Graceful Disconnection
@@ -558,8 +562,44 @@ Fields description:
 You can also use the `trabbits` CLI to get clients information:
 
 ```console
-$ trabbits manage clients
+$ trabbits manage clients list
 ```
+
+#### Shutdown a specific proxy
+
+You can gracefully shutdown a specific proxy by sending a DELETE request to the `/clients/{proxy_id}` endpoint.
+
+```console
+$ curl -X DELETE --unix-socket /tmp/trabbits.sock http://localhost/clients/proxy-12345678
+```
+
+You can also provide a custom shutdown reason using the `reason` query parameter:
+
+```console
+$ curl -X DELETE --unix-socket /tmp/trabbits.sock "http://localhost/clients/proxy-12345678?reason=Maintenance"
+```
+
+The response includes the shutdown status:
+
+```json
+{
+  "status": "shutdown_initiated",
+  "proxy_id": "proxy-12345678",
+  "reason": "Maintenance"
+}
+```
+
+Using the CLI:
+
+```console
+# Shutdown a proxy with default reason
+$ trabbits manage clients shutdown proxy-12345678
+
+# Shutdown a proxy with custom reason
+$ trabbits manage clients shutdown proxy-12345678 --reason "Scheduled maintenance"
+```
+
+The proxy will be gracefully disconnected, allowing it to properly close ongoing operations before termination.
 
 #### Reload configuration with SIGHUP
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ trabbits provides an HTTP API server that allows you to manage the configuration
 
 You can update the configuration of trabbits via the API server. You can get the current configuration and update with a new configuration via HTTP request to `/config` endpoint.
 
-trabbits cli also supports the configuration management. You can use `trabbits manage config` command to manage 
+trabbits cli also supports the configuration management. You can use `trabbits manage config` command to manage
 the configuration. The cli access to the API server on the localhost.
 
 ```
@@ -420,6 +420,14 @@ Manage the configuration.
 Arguments:
   <command>    Command to run (get, diff, put, reload).
   <file>       Configuration file (required for diff/put commands).
+```
+
+You can also get information about connected clients using the `trabbits manage clients` command:
+
+```
+Usage: trabbits manage clients
+
+Get connected clients information.
 ```
 
 #### Configuration Versioning and Graceful Disconnection
@@ -496,6 +504,62 @@ $ trabbits manage config reload
 ```
 
 This command reloads the configuration from the file specified by `--config` option (default: `config.json`).
+
+### Clients API
+
+trabbits provides an API to get information about connected clients. You can get the list of all connected clients by sending a GET request to the `/clients` endpoint.
+
+#### Get connected clients information
+
+You can get information about all connected clients by sending a GET request to the `/clients` endpoint.
+
+```console
+$ curl --unix-socket /tmp/trabbits.sock http://localhost/clients
+```
+
+The response includes the following information for each client:
+
+```json
+[
+  {
+    "id": "proxy-12345678",
+    "client_address": "127.0.0.1:54321",
+    "user": "guest",
+    "virtual_host": "/",
+    "client_banner": "Platform/Product/Version",
+    "connected_at": "2025-01-01T12:00:00Z",
+    "status": "active",
+    "shutdown_reason": ""
+  },
+  {
+    "id": "proxy-87654321",
+    "client_address": "127.0.0.1:54322",
+    "user": "guest",
+    "virtual_host": "/",
+    "client_banner": "Platform/Product/Version",
+    "connected_at": "2025-01-01T12:01:00Z",
+    "status": "shutting_down",
+    "shutdown_reason": "Configuration updated, please reconnect"
+  }
+]
+```
+
+Fields description:
+
+- `id`: Unique proxy identifier
+- `client_address`: Client's IP address and port
+- `user`: Authenticated username
+- `virtual_host`: Virtual host the client is connected to
+- `client_banner`: Client platform/product/version information
+- `connected_at`: Timestamp when the client connected
+- `status`: Connection status - either `active` or `shutting_down`
+- `shutdown_reason`: Reason for shutdown (only present when status is `shutting_down`)
+
+You can also use the `trabbits` CLI to get clients information:
+
+```console
+$ trabbits manage clients
+```
 
 #### Reload configuration with SIGHUP
 

--- a/api.go
+++ b/api.go
@@ -19,6 +19,10 @@ import (
 const (
 	APIContentType        = "application/json"
 	APIContentTypeJsonnet = "application/jsonnet"
+
+	// Client status constants
+	ClientStatusActive       = "active"
+	ClientStatusShuttingDown = "shutting_down"
 )
 
 // ClientInfo represents information about a connected client
@@ -29,7 +33,7 @@ type ClientInfo struct {
 	VirtualHost    string    `json:"virtual_host"`
 	ClientBanner   string    `json:"client_banner"`
 	ConnectedAt    time.Time `json:"connected_at"`
-	Status         string    `json:"status"` // "active" or "shutting_down"
+	Status         string    `json:"status"` // ClientStatusActive or ClientStatusShuttingDown
 	ShutdownReason string    `json:"shutdown_reason,omitempty"`
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -674,8 +674,8 @@ func TestAPIGetClients(t *testing.T) {
 
 		// Check first client (active)
 		client1 := clients[0]
-		if client1.Status != "active" {
-			t.Errorf("Expected status 'active', got '%s'", client1.Status)
+		if client1.Status != trabbits.ClientStatusActive {
+			t.Errorf("Expected status '%s', got '%s'", trabbits.ClientStatusActive, client1.Status)
 		}
 		if client1.User != "user1" {
 			t.Errorf("Expected user 'user1', got '%s'", client1.User)
@@ -692,8 +692,8 @@ func TestAPIGetClients(t *testing.T) {
 
 		// Check second client (shutting down)
 		client2 := clients[1]
-		if client2.Status != "shutting_down" {
-			t.Errorf("Expected status 'shutting_down', got '%s'", client2.Status)
+		if client2.Status != trabbits.ClientStatusShuttingDown {
+			t.Errorf("Expected status '%s', got '%s'", trabbits.ClientStatusShuttingDown, client2.Status)
 		}
 		if client2.User != "user2" {
 			t.Errorf("Expected user 'user2', got '%s'", client2.User)
@@ -791,8 +791,8 @@ func TestAPIGetClientsIntegration(t *testing.T) {
 			if clientInfo.ID == "" {
 				t.Error("Client ID should not be empty")
 			}
-			if clientInfo.Status != "active" {
-				t.Errorf("Expected status 'active', got '%s'", clientInfo.Status)
+			if clientInfo.Status != trabbits.ClientStatusActive {
+				t.Errorf("Expected status '%s', got '%s'", trabbits.ClientStatusActive, clientInfo.Status)
 			}
 			if clientInfo.ConnectedAt.IsZero() {
 				t.Error("ConnectedAt should not be zero value")

--- a/cli.go
+++ b/cli.go
@@ -59,6 +59,9 @@ func Run(ctx context.Context) error {
 	case "manage config <command>", "manage config <command> <file>":
 		// Manage the server
 		return manageConfig(ctx, &cli)
+	case "manage clients":
+		// Get clients information
+		return manageClients(ctx, &cli)
 	case "test match-routing <pattern> <key>":
 		// Test routing pattern matching
 		return testMatchRouting(ctx, &cli)
@@ -78,6 +81,7 @@ type ManageOptions struct {
 		Command string `arg:"" enum:"get,diff,put,reload" help:"Command to run (get, diff, put, reload)."`
 		File    string `arg:"" optional:"" help:"Configuration file (required for diff/put commands)."`
 	} `cmd:"" help:"Manage the configuration."`
+	Clients struct{} `cmd:"" help:"Get connected clients information."`
 }
 
 type TestOptions struct {

--- a/cli.go
+++ b/cli.go
@@ -59,9 +59,12 @@ func Run(ctx context.Context) error {
 	case "manage config <command>", "manage config <command> <file>":
 		// Manage the server
 		return manageConfig(ctx, &cli)
-	case "manage clients":
+	case "manage clients list":
 		// Get clients information
 		return manageClients(ctx, &cli)
+	case "manage clients shutdown <proxy-id>":
+		// Shutdown a specific proxy
+		return manageProxyShutdown(ctx, &cli)
 	case "test match-routing <pattern> <key>":
 		// Test routing pattern matching
 		return testMatchRouting(ctx, &cli)
@@ -81,7 +84,13 @@ type ManageOptions struct {
 		Command string `arg:"" enum:"get,diff,put,reload" help:"Command to run (get, diff, put, reload)."`
 		File    string `arg:"" optional:"" help:"Configuration file (required for diff/put commands)."`
 	} `cmd:"" help:"Manage the configuration."`
-	Clients struct{} `cmd:"" help:"Get connected clients information."`
+	Clients struct {
+		List struct{} `cmd:"" help:"Get connected clients information."`
+		Shutdown struct {
+			ProxyID string `arg:"" required:"" help:"Proxy ID to shutdown."`
+			Reason  string `help:"Optional shutdown reason."`
+		} `cmd:"" help:"Shutdown a specific proxy."`
+	} `cmd:"" help:"Manage connected clients."`
 }
 
 type TestOptions struct {

--- a/cli.go
+++ b/cli.go
@@ -65,6 +65,9 @@ func Run(ctx context.Context) error {
 	case "manage clients shutdown <proxy-id>":
 		// Shutdown a specific proxy
 		return manageProxyShutdown(ctx, &cli)
+	case "manage clients info <proxy-id>":
+		// Get detailed information for a specific proxy
+		return manageProxyInfo(ctx, &cli)
 	case "test match-routing <pattern> <key>":
 		// Test routing pattern matching
 		return testMatchRouting(ctx, &cli)
@@ -85,11 +88,14 @@ type ManageOptions struct {
 		File    string `arg:"" optional:"" help:"Configuration file (required for diff/put commands)."`
 	} `cmd:"" help:"Manage the configuration."`
 	Clients struct {
-		List struct{} `cmd:"" help:"Get connected clients information."`
+		List     struct{} `cmd:"" help:"Get connected clients information."`
 		Shutdown struct {
 			ProxyID string `arg:"" required:"" help:"Proxy ID to shutdown."`
 			Reason  string `help:"Optional shutdown reason."`
 		} `cmd:"" help:"Shutdown a specific proxy."`
+		Info struct {
+			ProxyID string `arg:"" required:"" help:"Proxy ID to get detailed information for."`
+		} `cmd:"" help:"Get detailed information for a specific proxy."`
 	} `cmd:"" help:"Manage connected clients."`
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -89,3 +89,8 @@ func (s *Server) TestGracefulStopProxy(clientAddr string, shutdownMessage string
 	})
 	return found
 }
+
+// Test-only method for accessing proxy statistics
+func (p *Proxy) Stats() *ProxyStats {
+	return p.stats
+}

--- a/export_test.go
+++ b/export_test.go
@@ -62,6 +62,16 @@ func (p *Proxy) SetShutdownMessage(message string) {
 	p.shutdownMessage = message
 }
 
+// Test-only method for setting proxy user
+func (p *Proxy) SetUser(user string) {
+	p.user = user
+}
+
+// Test-only method for setting proxy virtual host
+func (p *Proxy) SetVirtualHost(vhost string) {
+	p.VirtualHost = vhost
+}
+
 // Test-only method for gracefully stopping a specific proxy by client address
 func (s *Server) TestGracefulStopProxy(clientAddr string, shutdownMessage string) bool {
 	var found bool

--- a/export_test.go
+++ b/export_test.go
@@ -94,3 +94,12 @@ func (s *Server) TestGracefulStopProxy(clientAddr string, shutdownMessage string
 func (p *Proxy) Stats() *ProxyStats {
 	return p.stats
 }
+
+// Export manage functions for testing
+var (
+	ManageConfig        = manageConfig
+	ManageClients       = manageClients
+	ManageProxyInfo     = manageProxyInfo
+	ManageProxyShutdown = manageProxyShutdown
+	ColoredDiff         = coloredDiff
+)

--- a/manage_test.go
+++ b/manage_test.go
@@ -1,0 +1,42 @@
+package trabbits
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColoredDiff(t *testing.T) {
+	// Test the coloredDiff function with simple input/output
+	input := `- removed line
++ added line
+  unchanged line
+- another removed line
++ another added line`
+
+	result := coloredDiff(input)
+
+	// Check that the result contains the input (colors are applied but content preserved)
+	if !strings.Contains(result, "removed line") {
+		t.Error("coloredDiff should preserve removed lines")
+	}
+	if !strings.Contains(result, "added line") {
+		t.Error("coloredDiff should preserve added lines")
+	}
+	if !strings.Contains(result, "unchanged line") {
+		t.Error("coloredDiff should preserve unchanged lines")
+	}
+}
+
+func TestNewAPIClient(t *testing.T) {
+	// Test the newAPIClient function
+	socketPath := "/tmp/test.sock"
+	client := newAPIClient(socketPath)
+
+	if client == nil {
+		t.Fatal("newAPIClient should not return nil")
+	}
+
+	if client.endpoint != "http://localhost/" {
+		t.Errorf("Expected endpoint to be 'http://localhost/', got %s", client.endpoint)
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -41,21 +41,6 @@ type Proxy struct {
 	connectedAt        time.Time   // timestamp when the client connected
 }
 
-func NewProxy(conn net.Conn) *Proxy {
-	id := generateID()
-	p := &Proxy{
-		conn:               conn,
-		id:                 id,
-		r:                  amqp091.NewReader(conn),
-		w:                  amqp091.NewWriter(conn),
-		upstreamDisconnect: make(chan string, 10), // buffered to avoid blocking
-		shutdownMessage:    ShutdownMsgDefault,    // default shutdown message
-		connectedAt:        time.Now(),
-	}
-	p.logger = slog.New(slog.Default().Handler()).With("proxy", id, "client_addr", p.ClientAddr())
-	return p
-}
-
 func (p *Proxy) Upstreams() []*Upstream {
 	return p.upstreams
 }

--- a/proxy.go
+++ b/proxy.go
@@ -38,6 +38,7 @@ type Proxy struct {
 	configHash         string      // hash of config used for this proxy
 	upstreamDisconnect chan string // channel to notify upstream disconnection
 	shutdownMessage    string      // message to send when shutting down
+	connectedAt        time.Time   // timestamp when the client connected
 }
 
 func NewProxy(conn net.Conn) *Proxy {
@@ -49,6 +50,7 @@ func NewProxy(conn net.Conn) *Proxy {
 		w:                  amqp091.NewWriter(conn),
 		upstreamDisconnect: make(chan string, 10), // buffered to avoid blocking
 		shutdownMessage:    ShutdownMsgDefault,    // default shutdown message
+		connectedAt:        time.Now(),
 	}
 	p.logger = slog.New(slog.Default().Handler()).With("proxy", id, "client_addr", p.ClientAddr())
 	return p

--- a/proxy.go
+++ b/proxy.go
@@ -39,6 +39,7 @@ type Proxy struct {
 	upstreamDisconnect chan string // channel to notify upstream disconnection
 	shutdownMessage    string      // message to send when shutting down
 	connectedAt        time.Time   // timestamp when the client connected
+	stats              *ProxyStats // statistics for this proxy
 }
 
 func (p *Proxy) Upstreams() []*Upstream {

--- a/server.go
+++ b/server.go
@@ -119,6 +119,7 @@ func (s *Server) NewProxy(conn net.Conn) *Proxy {
 		connectionCloseTimeout: config.ConnectionCloseTimeout.ToDuration(),
 		shutdownMessage:        ShutdownMsgDefault, // default shutdown message
 		connectedAt:            time.Now(),         // timestamp when the client connected
+		stats:                  NewProxyStats(),    // initialize statistics
 	}
 	proxy.logger = slog.New(slog.Default().Handler()).With("proxy", id, "client_addr", proxy.ClientAddr())
 	return proxy
@@ -749,6 +750,10 @@ func (p *Proxy) runHeartbeat(ctx context.Context, interval uint16) {
 				p.shutdown(ctx)
 				return
 			}
+			// Count heartbeat frame
+			if p.stats != nil {
+				p.stats.IncrementSentFrames()
+			}
 			p.mu.Unlock()
 		}
 	}
@@ -809,6 +814,11 @@ func (p *Proxy) process(ctx context.Context) error {
 		}
 		return fmt.Errorf("failed to read frame: %w", err)
 	}
+
+	// Update frame statistics
+	if p.stats != nil {
+		p.stats.IncrementReceivedFrames()
+	}
 	GetMetrics().ClientReceivedFrames.Inc()
 
 	if mf, ok := frame.(*amqp091.MethodFrame); ok {
@@ -844,6 +854,10 @@ func (p *Proxy) dispatchN(ctx context.Context, frame amqp091.Frame) error {
 		}
 		methodName := strings.TrimLeft(reflect.TypeOf(f.Method).String(), "*amqp091.")
 		GetMetrics().ProcessedMessages.WithLabelValues(methodName).Inc()
+		// Update proxy-specific statistics
+		if p.stats != nil {
+			p.stats.IncrementMethod(methodName)
+		}
 		switch m := f.Method.(type) {
 		case *amqp091.ChannelOpen:
 			return p.replyChannelOpen(ctx, f, m)
@@ -920,6 +934,9 @@ func (p *Proxy) send(channel uint16, m amqp091.Message) error {
 			return fmt.Errorf("failed to write MethodFrame: %w", err)
 		}
 		GetMetrics().ClientSentFrames.Inc()
+		if p.stats != nil {
+			p.stats.IncrementSentFrames()
+		}
 
 		if err := p.w.WriteFrameNoFlush(&amqp091.HeaderFrame{
 			ChannelId:  uint16(channel),
@@ -930,6 +947,9 @@ func (p *Proxy) send(channel uint16, m amqp091.Message) error {
 			return fmt.Errorf("failed to write HeaderFrame: %w", err)
 		}
 		GetMetrics().ClientSentFrames.Inc()
+		if p.stats != nil {
+			p.stats.IncrementSentFrames()
+		}
 
 		// split body frame is it is too large (>= FrameMax)
 		// The overhead of BodyFrame is 8 bytes
@@ -947,6 +967,9 @@ func (p *Proxy) send(channel uint16, m amqp091.Message) error {
 			}
 			offset = end
 			GetMetrics().ClientSentFrames.Inc()
+			if p.stats != nil {
+				p.stats.IncrementSentFrames()
+			}
 		}
 	} else {
 		if err := p.w.WriteFrame(&amqp091.MethodFrame{
@@ -956,6 +979,9 @@ func (p *Proxy) send(channel uint16, m amqp091.Message) error {
 			return fmt.Errorf("failed to write MethodFrame: %w", err)
 		}
 		GetMetrics().ClientSentFrames.Inc()
+		if p.stats != nil {
+			p.stats.IncrementSentFrames()
+		}
 	}
 	return nil
 }
@@ -1059,10 +1085,22 @@ func (s *Server) GetClientsInfo() []ClientInfo {
 			User:             proxy.user,
 			VirtualHost:      proxy.VirtualHost,
 			ClientBanner:     proxy.ClientBanner(),
-			ClientProperties: proxy.clientProps,
+			ClientProperties: nil, // Nil for clients list to omit from JSON output
 			ConnectedAt:      proxy.connectedAt,
 			Status:           status,
 			ShutdownReason:   shutdownReason,
+		}
+
+		// Add statistics summary if available
+		if proxy.stats != nil {
+			snapshot := proxy.stats.Snapshot()
+			clientInfo.Stats = &StatsSummary{
+				TotalMethods:   snapshot.TotalMethods,
+				ReceivedFrames: snapshot.ReceivedFrames,
+				SentFrames:     snapshot.SentFrames,
+				TotalFrames:    snapshot.TotalFrames,
+				Duration:       snapshot.Duration,
+			}
 		}
 		clients = append(clients, clientInfo)
 		return true
@@ -1074,6 +1112,53 @@ func (s *Server) GetClientsInfo() []ClientInfo {
 	})
 
 	return clients
+}
+
+// GetClientInfo returns full client information including ClientProperties and complete stats
+func (s *Server) GetClientInfo(proxyID string) (*FullClientInfo, bool) {
+	value, ok := s.activeProxies.Load(proxyID)
+	if !ok {
+		return nil, false
+	}
+
+	entry := value.(*proxyEntry)
+	proxy := entry.proxy
+
+	// Determine status based on shutdown message
+	status := ClientStatusActive
+	shutdownReason := ""
+	if proxy.shutdownMessage != ShutdownMsgDefault {
+		status = ClientStatusShuttingDown
+		shutdownReason = proxy.shutdownMessage
+	}
+
+	clientInfo := &FullClientInfo{
+		ID:               proxy.id,
+		ClientAddress:    proxy.ClientAddr(),
+		User:             proxy.user,
+		VirtualHost:      proxy.VirtualHost,
+		ClientBanner:     proxy.ClientBanner(),
+		ClientProperties: proxy.clientProps, // Include full client properties
+		ConnectedAt:      proxy.connectedAt,
+		Status:           status,
+		ShutdownReason:   shutdownReason,
+	}
+
+	// Add complete statistics if available
+	if proxy.stats != nil {
+		snapshot := proxy.stats.Snapshot()
+		clientInfo.Stats = &FullStatsSummary{
+			StartedAt:      snapshot.StartedAt,
+			Methods:        snapshot.Methods,
+			TotalMethods:   snapshot.TotalMethods,
+			ReceivedFrames: snapshot.ReceivedFrames,
+			SentFrames:     snapshot.SentFrames,
+			TotalFrames:    snapshot.TotalFrames,
+			Duration:       snapshot.Duration,
+		}
+	}
+
+	return clientInfo, true
 }
 
 // ShutdownProxy gracefully shuts down a specific proxy by proxy ID

--- a/server.go
+++ b/server.go
@@ -117,6 +117,8 @@ func (s *Server) NewProxy(conn net.Conn) *Proxy {
 		configHash:             s.GetConfigHash(),
 		readTimeout:            config.ReadTimeout.ToDuration(),
 		connectionCloseTimeout: config.ConnectionCloseTimeout.ToDuration(),
+		shutdownMessage:        ShutdownMsgDefault, // default shutdown message
+		connectedAt:            time.Now(),         // timestamp when the client connected
 	}
 	proxy.logger = slog.New(slog.Default().Handler()).With("proxy", id, "client_addr", proxy.ClientAddr())
 	return proxy
@@ -1038,7 +1040,7 @@ func (s *Server) CountActiveProxies() int {
 
 // GetClientsInfo returns information about all connected clients
 func (s *Server) GetClientsInfo() []ClientInfo {
-	var clients []ClientInfo
+	clients := make([]ClientInfo, 0) // Initialize as empty slice instead of nil
 	s.activeProxies.Range(func(key, value interface{}) bool {
 		entry := value.(*proxyEntry)
 		proxy := entry.proxy

--- a/server.go
+++ b/server.go
@@ -1046,10 +1046,10 @@ func (s *Server) GetClientsInfo() []ClientInfo {
 		proxy := entry.proxy
 
 		// Determine status based on shutdown message
-		status := "active"
+		status := ClientStatusActive
 		shutdownReason := ""
 		if proxy.shutdownMessage != ShutdownMsgDefault {
-			status = "shutting_down"
+			status = ClientStatusShuttingDown
 			shutdownReason = proxy.shutdownMessage
 		}
 

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,129 @@
+package trabbits
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ProxyStats holds statistics for a single proxy connection
+type ProxyStats struct {
+	startedAt      time.Time
+	methodCounts   sync.Map // map[string]*int64 - key: method name, value: counter
+	receivedFrames int64    // frames received from client (atomic)
+	sentFrames     int64    // frames sent to client (atomic)
+}
+
+// NewProxyStats creates a new ProxyStats instance
+func NewProxyStats() *ProxyStats {
+	return &ProxyStats{
+		startedAt: time.Now(),
+	}
+}
+
+// IncrementMethod increments the counter for a specific AMQP method
+func (s *ProxyStats) IncrementMethod(method string) {
+	// Update local counter
+	v, _ := s.methodCounts.LoadOrStore(method, new(int64))
+	atomic.AddInt64(v.(*int64), 1)
+
+	// Also update global Prometheus metrics
+	if m := GetMetrics(); m != nil {
+		m.ProcessedMessages.WithLabelValues(method).Inc()
+	}
+}
+
+// IncrementReceivedFrames increments the received frame counter
+func (s *ProxyStats) IncrementReceivedFrames() {
+	atomic.AddInt64(&s.receivedFrames, 1)
+
+	// Also update global Prometheus metrics
+	if m := GetMetrics(); m != nil {
+		m.ClientReceivedFrames.Inc()
+	}
+}
+
+// IncrementSentFrames increments the sent frame counter
+func (s *ProxyStats) IncrementSentFrames() {
+	atomic.AddInt64(&s.sentFrames, 1)
+
+	// Also update global Prometheus metrics
+	if m := GetMetrics(); m != nil {
+		m.ClientSentFrames.Inc()
+	}
+}
+
+// GetMethodCount returns the count for a specific method
+func (s *ProxyStats) GetMethodCount(method string) int64 {
+	v, ok := s.methodCounts.Load(method)
+	if !ok {
+		return 0
+	}
+	return atomic.LoadInt64(v.(*int64))
+}
+
+// GetAllMethodCounts returns a map of all method counts
+func (s *ProxyStats) GetAllMethodCounts() map[string]int64 {
+	result := make(map[string]int64)
+	s.methodCounts.Range(func(key, value interface{}) bool {
+		method := key.(string)
+		count := atomic.LoadInt64(value.(*int64))
+		result[method] = count
+		return true
+	})
+	return result
+}
+
+// GetReceivedFrames returns the number of frames received from client
+func (s *ProxyStats) GetReceivedFrames() int64 {
+	return atomic.LoadInt64(&s.receivedFrames)
+}
+
+// GetSentFrames returns the number of frames sent to client
+func (s *ProxyStats) GetSentFrames() int64 {
+	return atomic.LoadInt64(&s.sentFrames)
+}
+
+// GetTotalFrames returns the total number of frames (received + sent)
+func (s *ProxyStats) GetTotalFrames() int64 {
+	return s.GetReceivedFrames() + s.GetSentFrames()
+}
+
+// GetTotalMethods returns the total number of methods processed
+func (s *ProxyStats) GetTotalMethods() int64 {
+	var total int64
+	s.methodCounts.Range(func(_, value interface{}) bool {
+		total += atomic.LoadInt64(value.(*int64))
+		return true
+	})
+	return total
+}
+
+// GetStartedAt returns when the stats collection started
+func (s *ProxyStats) GetStartedAt() time.Time {
+	return s.startedAt
+}
+
+// StatsSnapshot represents a point-in-time snapshot of proxy statistics
+type StatsSnapshot struct {
+	StartedAt      time.Time        `json:"started_at"`
+	Methods        map[string]int64 `json:"methods"`
+	TotalMethods   int64            `json:"total_methods"`
+	ReceivedFrames int64            `json:"received_frames"`
+	SentFrames     int64            `json:"sent_frames"`
+	TotalFrames    int64            `json:"total_frames"`
+	Duration       string           `json:"duration"`
+}
+
+// Snapshot returns a snapshot of current statistics
+func (s *ProxyStats) Snapshot() StatsSnapshot {
+	return StatsSnapshot{
+		StartedAt:      s.startedAt,
+		Methods:        s.GetAllMethodCounts(),
+		TotalMethods:   s.GetTotalMethods(),
+		ReceivedFrames: s.GetReceivedFrames(),
+		SentFrames:     s.GetSentFrames(),
+		TotalFrames:    s.GetTotalFrames(),
+		Duration:       time.Since(s.startedAt).String(),
+	}
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,167 @@
+package trabbits_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fujiwara/trabbits"
+	"github.com/fujiwara/trabbits/config"
+)
+
+func TestProxyStats(t *testing.T) {
+	// Create a new stats instance
+	stats := trabbits.NewProxyStats()
+
+	// Test initial state
+	if stats.GetTotalMethods() != 0 {
+		t.Errorf("Expected initial total methods to be 0, got %d", stats.GetTotalMethods())
+	}
+	if stats.GetTotalFrames() != 0 {
+		t.Errorf("Expected initial total frames to be 0, got %d", stats.GetTotalFrames())
+	}
+
+	// Test incrementing methods
+	stats.IncrementMethod("Basic.Publish")
+	stats.IncrementMethod("Basic.Publish")
+	stats.IncrementMethod("Queue.Declare")
+
+	if stats.GetMethodCount("Basic.Publish") != 2 {
+		t.Errorf("Expected Basic.Publish count to be 2, got %d", stats.GetMethodCount("Basic.Publish"))
+	}
+	if stats.GetMethodCount("Queue.Declare") != 1 {
+		t.Errorf("Expected Queue.Declare count to be 1, got %d", stats.GetMethodCount("Queue.Declare"))
+	}
+	if stats.GetTotalMethods() != 3 {
+		t.Errorf("Expected total methods to be 3, got %d", stats.GetTotalMethods())
+	}
+
+	// Test incrementing frames
+	stats.IncrementReceivedFrames()
+	stats.IncrementReceivedFrames()
+	stats.IncrementReceivedFrames()
+	stats.IncrementSentFrames()
+	stats.IncrementSentFrames()
+
+	if stats.GetReceivedFrames() != 3 {
+		t.Errorf("Expected received frames to be 3, got %d", stats.GetReceivedFrames())
+	}
+	if stats.GetSentFrames() != 2 {
+		t.Errorf("Expected sent frames to be 2, got %d", stats.GetSentFrames())
+	}
+	if stats.GetTotalFrames() != 5 {
+		t.Errorf("Expected total frames to be 5, got %d", stats.GetTotalFrames())
+	}
+
+	// Test snapshot
+	snapshot := stats.Snapshot()
+	if snapshot.TotalMethods != 3 {
+		t.Errorf("Expected snapshot total methods to be 3, got %d", snapshot.TotalMethods)
+	}
+	if snapshot.ReceivedFrames != 3 {
+		t.Errorf("Expected snapshot received frames to be 3, got %d", snapshot.ReceivedFrames)
+	}
+	if snapshot.SentFrames != 2 {
+		t.Errorf("Expected snapshot sent frames to be 2, got %d", snapshot.SentFrames)
+	}
+	if snapshot.TotalFrames != 5 {
+		t.Errorf("Expected snapshot total frames to be 5, got %d", snapshot.TotalFrames)
+	}
+	if len(snapshot.Methods) != 2 {
+		t.Errorf("Expected 2 methods in snapshot, got %d", len(snapshot.Methods))
+	}
+	if snapshot.Methods["Basic.Publish"] != 2 {
+		t.Errorf("Expected Basic.Publish count in snapshot to be 2, got %d", snapshot.Methods["Basic.Publish"])
+	}
+
+	// Test duration
+	time.Sleep(10 * time.Millisecond)
+	snapshot2 := stats.Snapshot()
+	if snapshot2.Duration == "" {
+		t.Error("Expected duration to be non-empty")
+	}
+}
+
+func TestProxyStatsAPI(t *testing.T) {
+	// Test the basic functionality with a simple unit test
+	cfg := &config.Config{
+		Upstreams: []config.Upstream{
+			{Name: "test", Address: "localhost:5672"},
+		},
+	}
+	server := trabbits.NewTestServer(cfg)
+	proxy := server.NewProxy(nil)
+	proxy.SetUser("testuser")
+	proxy.SetVirtualHost("/test")
+
+	// Simulate some method calls
+	if proxy.Stats() != nil {
+		proxy.Stats().IncrementMethod("Basic.Publish")
+		proxy.Stats().IncrementMethod("Basic.Publish")
+		proxy.Stats().IncrementMethod("Basic.Consume")
+		proxy.Stats().IncrementReceivedFrames()
+		proxy.Stats().IncrementReceivedFrames()
+		proxy.Stats().IncrementSentFrames()
+	}
+
+	// Check if stats are correctly updated
+	if proxy.Stats().GetTotalMethods() != 3 {
+		t.Errorf("Expected total methods to be 3, got %d", proxy.Stats().GetTotalMethods())
+	}
+	if proxy.Stats().GetTotalFrames() != 3 {
+		t.Errorf("Expected total frames to be 3, got %d", proxy.Stats().GetTotalFrames())
+	}
+	if proxy.Stats().GetMethodCount("Basic.Publish") != 2 {
+		t.Errorf("Expected Basic.Publish count to be 2, got %d", proxy.Stats().GetMethodCount("Basic.Publish"))
+	}
+}
+
+// TestProxyStatsInClientInfo verifies that stats are included in the clients list
+func TestProxyStatsInClientInfo(t *testing.T) {
+	cfg := &config.Config{
+		Upstreams: []config.Upstream{
+			{Name: "test", Address: "localhost:5672"},
+		},
+	}
+	server := trabbits.NewTestServer(cfg)
+
+	// Create a proxy with some activity
+	proxy := server.NewProxy(nil)
+	proxy.SetUser("testuser")
+	proxy.SetVirtualHost("/test")
+
+	// Simulate some method calls
+	if proxy.Stats() != nil {
+		proxy.Stats().IncrementMethod("Basic.Publish")
+		proxy.Stats().IncrementMethod("Queue.Declare")
+		for i := 0; i < 6; i++ {
+			proxy.Stats().IncrementReceivedFrames()
+		}
+		for i := 0; i < 4; i++ {
+			proxy.Stats().IncrementSentFrames()
+		}
+	}
+
+	server.RegisterProxy(proxy, func() {})
+	defer server.UnregisterProxy(proxy)
+
+	// Get clients info
+	clients := server.GetClientsInfo()
+	if len(clients) != 1 {
+		t.Fatalf("Expected 1 client, got %d", len(clients))
+	}
+
+	client := clients[0]
+	if client.Stats == nil {
+		t.Fatal("Expected stats to be present in ClientInfo")
+	}
+
+	if client.Stats.TotalMethods != 2 {
+		t.Errorf("Expected total methods to be 2, got %d", client.Stats.TotalMethods)
+	}
+	if client.Stats.TotalFrames != 10 {
+		t.Errorf("Expected total frames to be 10, got %d", client.Stats.TotalFrames)
+	}
+	if client.Stats.Duration == "" {
+		t.Error("Expected duration to be non-empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Replace `clients stats` command with comprehensive `clients info` for full client details
- Add proxy-level statistics tracking for AMQP methods and frames  
- Implement complete clients management API with proper data separation
- Remove deprecated stats-only endpoint in favor of unified approach

## New Features
- **CLI Command**: `trabbits manage clients info <proxy-id>` for detailed client information
- **API Endpoint**: `GET /clients/{proxy_id}` returns full client info including ClientProperties and complete statistics
- **Statistics Tracking**: Per-proxy AMQP method counts and separate received/sent frame counters
- **Data Optimization**: ClientProperties omitted from clients list but included in individual client details

## API Changes
- **Added**: `GET /clients/{proxy_id}` - Complete client information with full statistics
- **Removed**: `GET /clients/{proxy_id}/stats` - Replaced by comprehensive info endpoint
- **Enhanced**: `GET /clients` - Now includes summary statistics and optimized data structure

## Technical Improvements
- Consistent with existing Prometheus metrics (separate received/sent frame counters)
- Thread-safe statistics using `sync.Map` with atomic operations
- Comprehensive test coverage including integration tests
- Proper JSON structure with `omitempty` tags for optimal API responses

## Test Plan
- [x] Unit tests for statistics tracking and API endpoints
- [x] Integration tests with real AMQP connections
- [x] CLI command functionality verification
- [x] JSON output format validation
- [x] Thread safety and performance testing

🤖 Generated with [Claude Code](https://claude.ai/code)