### PR TITLE
Fix ShutdownClient to use DELETE method instead of POST

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -16,6 +16,17 @@ type Client struct {
 
 // New creates a new API client that communicates via Unix socket
 func New(socketPath string) *Client {
+	// If socketPath starts with "http://" or "https://", treat it as an HTTP endpoint (for testing)
+	if u, err := url.Parse(socketPath); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+		return &Client{
+			endpoint: socketPath,
+			client: &http.Client{
+				Timeout: 30 * time.Second,
+			},
+		}
+	}
+
+	// Otherwise, treat it as a Unix socket path
 	tr := &http.Transport{
 		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 			return net.Dial("unix", socketPath)

--- a/apiclient/proxy_test.go
+++ b/apiclient/proxy_test.go
@@ -1,7 +1,6 @@
 package apiclient_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +88,7 @@ func TestShutdownClient(t *testing.T) {
 			client := apiclient.New(server.URL)
 
 			// Call ShutdownClient
-			err := client.ShutdownClient(context.Background(), tt.clientID, tt.reason)
+			err := client.ShutdownClient(t.Context(), tt.clientID, tt.reason)
 
 			// Check error expectation
 			if tt.expectError {
@@ -127,7 +126,7 @@ func TestShutdownClient_CorrectMethod(t *testing.T) {
 	client := apiclient.New(server.URL)
 
 	// This should succeed since we're using DELETE method
-	err := client.ShutdownClient(context.Background(), "test-client", "test reason")
+	err := client.ShutdownClient(t.Context(), "test-client", "test reason")
 
 	// Verify no error
 	if err != nil {

--- a/apiclient/proxy_test.go
+++ b/apiclient/proxy_test.go
@@ -1,0 +1,141 @@
+package apiclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fujiwara/trabbits/apiclient"
+)
+
+func TestShutdownClient(t *testing.T) {
+	tests := []struct {
+		name           string
+		clientID       string
+		reason         string
+		serverHandler  http.HandlerFunc
+		expectError    bool
+		expectedMethod string
+		expectedPath   string
+	}{
+		{
+			name:           "successful shutdown with DELETE method",
+			clientID:       "test-client-123",
+			reason:         "test shutdown",
+			expectedMethod: "DELETE",
+			expectedPath:   "/clients/test-client-123",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				// Verify the correct method is used
+				if r.Method != "DELETE" {
+					t.Errorf("expected DELETE method, got %s", r.Method)
+					http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				// Verify the path
+				if r.URL.Path != "/clients/test-client-123" {
+					t.Errorf("expected path /clients/test-client-123, got %s", r.URL.Path)
+					http.Error(w, "Not Found", http.StatusNotFound)
+					return
+				}
+				// Verify reason is passed as query parameter
+				reason := r.URL.Query().Get("reason")
+				if reason != "test shutdown" {
+					t.Errorf("expected reason 'test shutdown', got %s", reason)
+				}
+
+				// Return success response
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]string{
+					"status":   "shutdown_initiated",
+					"proxy_id": "test-client-123",
+					"reason":   reason,
+				})
+			},
+			expectError: false,
+		},
+		{
+			name:           "client not found",
+			clientID:       "non-existent-client",
+			reason:         "",
+			expectedMethod: "DELETE",
+			expectedPath:   "/clients/non-existent-client",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "Proxy not found", http.StatusNotFound)
+			},
+			expectError: true,
+		},
+		{
+			name:           "empty client ID",
+			clientID:       "",
+			reason:         "test",
+			expectedMethod: "DELETE",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				// This should not be called since validation happens client-side
+				t.Error("handler should not be called for empty client ID")
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(tt.serverHandler)
+			defer server.Close()
+
+			// Create client with test server URL
+			client := apiclient.New(server.URL)
+
+			// Call ShutdownClient
+			err := client.ShutdownClient(context.Background(), tt.clientID, tt.reason)
+
+			// Check error expectation
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestShutdownClient_CorrectMethod verifies that DELETE method is used correctly
+func TestShutdownClient_CorrectMethod(t *testing.T) {
+	// This test verifies that the client correctly uses DELETE method
+	methodCalled := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methodCalled = r.Method
+		// The API server expects DELETE method
+		if r.Method != "DELETE" {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":   "shutdown_initiated",
+			"proxy_id": "test-client",
+		})
+	}))
+	defer server.Close()
+
+	client := apiclient.New(server.URL)
+
+	// This should succeed since we're using DELETE method
+	err := client.ShutdownClient(context.Background(), "test-client", "test reason")
+
+	// Verify no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify DELETE method was used
+	if methodCalled != "DELETE" {
+		t.Errorf("expected DELETE method to be called, got %s", methodCalled)
+	}
+}

--- a/proxy_disconnect_integration_test.go
+++ b/proxy_disconnect_integration_test.go
@@ -49,7 +49,7 @@ func TestConfigUpdateDisconnectsOutdatedProxies(t *testing.T) {
 	// Create a proxy with old config hash for internal logic testing
 	proxy := testServer.NewProxy(nil)
 	proxy.SetConfigHash(oldHash)
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	testServer.RegisterProxy(proxy, cancel)
 

--- a/proxy_disconnect_rate_limit_test.go
+++ b/proxy_disconnect_rate_limit_test.go
@@ -44,7 +44,7 @@ func TestDisconnectOutdatedProxies_RateLimit(t *testing.T) {
 	for i := 0; i < numProxies; i++ {
 		proxy := testServer.NewProxy(nil) // Use nil connection for internal logic testing
 		proxy.SetConfigHash(oldHash)
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		testServer.RegisterProxy(proxy, cancel)
 		proxies = append(proxies, proxy)
@@ -127,7 +127,7 @@ func TestDisconnectOutdatedProxies_TimeoutCalculation(t *testing.T) {
 	for i := 0; i < numProxies; i++ {
 		proxy := testServer.NewProxy(nil) // Use nil connection for internal logic testing
 		proxy.SetConfigHash(oldHash)
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		testServer.RegisterProxy(proxy, cancel)
 		proxies = append(proxies, proxy)

--- a/proxy_disconnect_zero_test.go
+++ b/proxy_disconnect_zero_test.go
@@ -29,7 +29,7 @@ func TestDisconnectOutdatedProxies_ZeroProxies(t *testing.T) {
 	// Create proxy with CURRENT config hash (not outdated)
 	proxy := testServer.NewProxy(nil)
 	proxy.SetConfigHash(configHash) // Same hash as current config
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	testServer.RegisterProxy(proxy, cancel)
 

--- a/proxy_management_test.go
+++ b/proxy_management_test.go
@@ -30,7 +30,7 @@ func TestProxyRegistration(t *testing.T) {
 	proxy := server.NewProxy(nil)
 
 	// Register proxy with dummy cancel function for testing
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	server.RegisterProxy(proxy, cancel)
 
@@ -96,13 +96,13 @@ func TestDisconnectOutdatedProxies(t *testing.T) {
 	// Create proxies and manually set different config hashes
 	proxy1 := server.NewProxy(nil)
 	proxy1.SetConfigHash(oldHash) // This proxy has old config
-	_, cancel1 := context.WithCancel(context.Background())
+	_, cancel1 := context.WithCancel(t.Context())
 	defer cancel1()
 	server.RegisterProxy(proxy1, cancel1)
 
 	proxy2 := server.NewProxy(nil)
 	proxy2.SetConfigHash(newHash) // This proxy has new config
-	_, cancel2 := context.WithCancel(context.Background())
+	_, cancel2 := context.WithCancel(t.Context())
 	defer cancel2()
 	server.RegisterProxy(proxy2, cancel2)
 

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -46,7 +46,7 @@ func TestGracefulShutdown(t *testing.T) {
 
 	for i := 0; i < numProxies; i++ {
 		proxy := testServer.NewProxy(nil) // Use nil connection for internal logic testing
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		testServer.RegisterProxy(proxy, cancel)
 		proxies = append(proxies, proxy)
@@ -164,12 +164,12 @@ func TestGracefulShutdown_ContextCancellation(t *testing.T) {
 
 	// Create a proxy for internal logic testing
 	proxy := testServer.NewProxy(nil)
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	testServer.RegisterProxy(proxy, cancel)
 
 	// Create a context that we can cancel
-	ctx, testCancel := context.WithCancel(context.Background())
+	ctx, testCancel := context.WithCancel(t.Context())
 
 	// Create a mock listener
 	listener, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary
- Fixed `ShutdownClient` API client method to use correct HTTP DELETE method
- Changed endpoint path from `/clients/{id}/shutdown` to `/clients/{id}`
- Added comprehensive tests for the ShutdownClient functionality

## Changes
- **apiclient/proxy.go**: Updated ShutdownClient to use DELETE method and correct endpoint path
- **apiclient/client.go**: Added HTTP endpoint support for testing
- **apiclient/proxy_test.go**: Added tests to verify correct HTTP method usage

## Problem
The `trabbits manage clients shutdown` command was failing with "405 Method Not Allowed" error because the API client was using POST method while the server expected DELETE method.

## Solution
Updated the API client to use the correct DELETE method and endpoint path as defined in the server's API routes.

## Test plan
- [x] Added unit tests for ShutdownClient method
- [x] All tests pass (`go test ./apiclient`)
- [x] Fixed endpoint correctly uses DELETE method

🤖 Generated with [Claude Code](https://claude.ai/code)