### PR TITLE
Fix timeout issue for streaming probe logs

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -8,37 +8,47 @@ import (
 	"time"
 )
 
+const (
+	// DefaultTimeout is the default timeout for regular API requests
+	DefaultTimeout = 30 * time.Second
+)
+
 // Client represents a client for communicating with trabbits API server via Unix socket
 type Client struct {
-	endpoint string
-	client   *http.Client
+	endpoint     string
+	client       *http.Client
+	streamClient *http.Client // HTTP client without timeout for streaming operations
 }
 
 // New creates a new API client that communicates via Unix socket
 func New(socketPath string) *Client {
+	var transport http.RoundTripper
+	var endpoint string
+
 	// If socketPath starts with "http://" or "https://", treat it as an HTTP endpoint (for testing)
 	if u, err := url.Parse(socketPath); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
-		return &Client{
-			endpoint: socketPath,
-			client: &http.Client{
-				Timeout: 30 * time.Second,
+		endpoint = socketPath
+		transport = http.DefaultTransport
+	} else {
+		// Otherwise, treat it as a Unix socket path
+		endpoint = "http://localhost/"
+		transport = &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
 			},
 		}
 	}
 
-	// Otherwise, treat it as a Unix socket path
-	tr := &http.Transport{
-		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-			return net.Dial("unix", socketPath)
-		},
-	}
-	client := &http.Client{
-		Transport: tr,
-		Timeout:   30 * time.Second,
-	}
 	return &Client{
-		endpoint: "http://localhost/",
-		client:   client,
+		endpoint: endpoint,
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   DefaultTimeout,
+		},
+		streamClient: &http.Client{
+			Transport: transport,
+			// No timeout for streaming operations
+		},
 	}
 }
 

--- a/apiclient/probe.go
+++ b/apiclient/probe.go
@@ -56,7 +56,7 @@ func (c *Client) readProbeLogSSE(ctx context.Context, proxyID string, handler fu
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	resp, err := c.client.Do(req)
+	resp, err := c.streamClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Fixed timeout errors that occurred during long-running `manage clients probe` sessions
- Refactored client initialization to eliminate code duplication

## Problem
When running `trabbits manage clients probe <proxy-id>` for extended periods (>30 seconds), the command would fail with:
```
{"time":"2025-09-26T11:46:20.738178304+09:00","level":"ERROR","msg":"StreamProbeLogEntries error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","proxy_id":"sb4c2b6uuydv2ttq4yjxip6tsp"}
```

## Solution
- Created a separate HTTP client without timeout specifically for streaming operations
- Regular API calls continue to use the 30-second timeout for protection
- Extracted timeout value as a constant (`DefaultTimeout`) for better maintainability
- Refactored client initialization to share transport between both clients

🤖 Generated with [Claude Code](https://claude.ai/code)