### PR TITLE
Increase TUI column widths for better readability

### DIFF
--- a/tui/format.go
+++ b/tui/format.go
@@ -19,18 +19,18 @@ var (
 
 // formatID formats a client ID for display
 func formatID(id string) string {
-	if len(id) <= 8 {
+	if len(id) <= 10 {
 		return id
 	}
-	return id[:6] + ".."
+	return id[:8] + ".."
 }
 
 // formatAddress formats a client address for display
 func formatAddress(addr string) string {
-	if len(addr) <= 15 {
+	if len(addr) <= 21 {
 		return addr
 	}
-	return addr[:15]
+	return addr[:21]
 }
 
 // formatStatus formats a client status with color
@@ -113,6 +113,6 @@ func (m *TUIModel) formatClientRow(client types.ClientInfo, selected bool) strin
 	methods := formatNumber(getStatValue(client.Stats, "total_methods"))
 	frames := formatNumber(getStatValue(client.Stats, "total_frames"))
 
-	return fmt.Sprintf("%s %-8s %-8s %-8s %-15s %-8s %-10s %-8s %-8s",
+	return fmt.Sprintf("%s %-10s %-8s %-8s %-21s %-8s %-10s %-8s %-8s",
 		prefix, id, user, vhost, address, status, connected, methods, frames)
 }

--- a/tui/format_test.go
+++ b/tui/format_test.go
@@ -22,9 +22,14 @@ func TestFormatID(t *testing.T) {
 			expected: "abcd1234",
 		},
 		{
+			name:     "exact 10 chars",
+			input:    "abcd123456",
+			expected: "abcd123456",
+		},
+		{
 			name:     "long ID",
 			input:    "abcdefghijklmnop",
-			expected: "abcdef..",
+			expected: "abcdefgh..",
 		},
 	}
 

--- a/tui/view.go
+++ b/tui/view.go
@@ -117,7 +117,7 @@ func (m *TUIModel) renderTable() string {
 
 	var rows []string
 
-	header := "ID       User     VHost    Address         Status    Connected  Methods  Frames"
+	header := "ID         User     VHost    Address              Status    Connected  Methods  Frames"
 	rows = append(rows, header)
 	rows = append(rows, strings.Repeat("─", len(header)))
 


### PR DESCRIPTION
## Summary
- Expand ID column from 6 to 8 characters display
- Expand Address column from 15 to 21 characters display

This fixes the issue where client IDs and addresses were being truncated too aggressively in the TUI list view, making it difficult to distinguish between clients.

## Test plan
- [x] Build and run the TUI
- [x] Verify ID column shows 8 characters before truncation
- [x] Verify Address column shows full IP:port combinations (e.g., `10.152.0.31:34700`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)