### PR TITLE
add 'on upstream' into log messages.

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -100,7 +100,7 @@ func (p *Proxy) GetChannels(id uint16) ([]*rabbitmq.Channel, error) {
 	for _, us := range p.upstreams {
 		ch, err := us.GetChannel(id)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get channel %d on upstream %s: %w", id, us.String(), err)
 		}
 		chs = append(chs, ch)
 	}
@@ -143,7 +143,7 @@ func (p *Proxy) ClientAddr() string {
 func (p *Proxy) Close() {
 	for _, us := range p.Upstreams() {
 		if err := us.Close(); err != nil {
-			us.logger.Warn("failed to close upstream", "error", err)
+			us.logger.Warn("failed to close upstream", "error", err, "upstream", us.String())
 		}
 	}
 }
@@ -151,7 +151,7 @@ func (p *Proxy) Close() {
 func (p *Proxy) NewChannel(id uint16) error {
 	for _, us := range p.Upstreams() {
 		if _, err := us.NewChannel(id); err != nil {
-			return fmt.Errorf("failed to create channel: %w", err)
+			return fmt.Errorf("failed to create channel on upstream %s: %w", us.String(), err)
 		}
 	}
 	return nil
@@ -160,7 +160,7 @@ func (p *Proxy) NewChannel(id uint16) error {
 func (p *Proxy) CloseChannel(id uint16) error {
 	for _, us := range p.Upstreams() {
 		if err := us.CloseChannel(id); err != nil {
-			return err
+			return fmt.Errorf("failed to close channel on upstream %s: %w", us.String(), err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This pull request improves error reporting throughout the proxy logic by including the upstream identifier in all error messages. This makes it easier to diagnose issues in multi-upstream scenarios by clearly indicating which upstream caused a failure. The changes affect both error returns and logging statements across several methods dealing with channels, queues, exchanges, and consumers.

**Enhanced Error Reporting**

* All error messages related to channel operations now include the upstream identifier, aiding in debugging multi-upstream issues. (`proxy.go`, `methods.go`) [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L103-R103) [[2]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L163-R163) [[3]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL128-R128) [[4]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL208-R212) [[5]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL352-R360)
* Error messages for queue, exchange, and consumer operations have been updated to specify the upstream, improving traceability of failures. (`methods.go`) [[1]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL63-R63) [[2]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL141-R141) [[3]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL291-R291) [[4]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL315-R315) [[5]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL338-R338) [[6]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL382-R382) [[7]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL407-R407) [[8]](diffhunk://#diff-1b80e660fccb740c483bb23c07833bc1ef560c7cec2cdb6737a81bab03e3591dL425-R425)

**Improved Logging**

* Logging for upstream closure now includes the upstream identifier for better visibility in logs. (`proxy.go`)

**Channel Lifecycle Management**

* Channel creation errors now specify the upstream, making it easier to pinpoint which upstream failed during channel creation. (`proxy.go`)