### PR TITLE
Enhance TUI with improved probe log display and server log streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ The TUI provides a real-time, top-like interface with the following features:
 - `Home/End`: Jump to first/last client
 - `Enter`: View detailed client information
 - `p`: Start probe log streaming for selected client
+- `l`: View server logs (dedicated full-screen view)
 - `Shift+K`: Shutdown selected client (with confirmation)
 - `r`: Force refresh
 - `q`: Quit
@@ -489,11 +490,27 @@ The TUI provides a real-time, top-like interface with the following features:
 
 **Probe Log View:**
 - Real-time streaming of AMQP protocol events for selected client
-- Shows method calls with structured attributes (routing keys, message properties, etc.)
+- Shows method calls with structured attributes in JSON format (routing keys, message properties, etc.)
 - Scrollable log viewer with auto-scroll behavior
 - Navigation controls: `↑↓/kj` to scroll, `Home/End` to jump, `PgUp/PgDn` for page navigation
-- Auto-scroll automatically disables when scrolling up to view older logs
-- Press `End` to re-enable auto-scroll and jump to latest logs
+- Auto-scroll control: `SPACE` to toggle auto-scroll on/off
+  - Auto-scroll automatically disables when scrolling up to view older logs
+  - Press `SPACE` or `End` to re-enable auto-scroll and jump to latest logs
+  - Current auto-scroll status displayed in help text
+- Save logs to file: `s` to open save dialog
+  - Default filename format: `{client-id}-{timestamp}.log`
+  - Edit file path with `e` key (supports full text editing with cursor navigation)
+  - Logs saved in JSON Lines format for easy processing
+  - ENTER to save, ESC/n to cancel
+- `q/Esc`: Return to main client list
+
+**Server Logs View:**
+- Dedicated full-screen view for reviewing server logs
+- Shows all recent server logs (last 100 entries) with structured attributes in JSON format
+- Scrollable viewer with full navigation support
+- Navigation controls: `↑↓/kj` to scroll, `Home/End` to jump, `PgUp/PgDn` for page navigation
+- Each log entry shows timestamp, level (INFO/DEBUG/ERROR), message, and attributes
+- Useful for monitoring server health and debugging issues
 - `q/Esc`: Return to main client list
 
 **Client Shutdown:**
@@ -506,6 +523,8 @@ The TUI provides a real-time, top-like interface with the following features:
 - **No Terminal Disruption**: Unlike `curl` commands, the TUI doesn't clutter your terminal with JSON output
 - **Real-time Monitoring**: See client connections, disconnections, and activity as it happens
 - **Live Protocol Inspection**: Stream real-time AMQP protocol events and method calls for debugging
+- **Server Log Integration**: View server logs directly in TUI for comprehensive monitoring
+- **Log Persistence**: Save probe logs to file for offline analysis and troubleshooting
 - **Efficient Navigation**: Quickly browse through many clients without manual ID copying
 - **Comprehensive Information**: All client details in an easy-to-read format
 - **Safe Operations**: Confirmation dialogs prevent accidental shutdowns

--- a/apiclient/interface.go
+++ b/apiclient/interface.go
@@ -23,6 +23,9 @@ type APIClient interface {
 
 	// Probe operations
 	StreamProbeLogEntries(ctx context.Context, proxyID string) (<-chan types.ProbeLogEntry, error)
+
+	// Server log operations
+	StreamServerLogs(ctx context.Context) (<-chan types.ProbeLogEntry, error)
 }
 
 // Ensure that Client implements APIClient

--- a/log_buffer.go
+++ b/log_buffer.go
@@ -1,0 +1,174 @@
+package trabbits
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/fujiwara/trabbits/types"
+)
+
+// LogBuffer stores recent log entries and broadcasts them to listeners
+type LogBuffer struct {
+	mu        sync.RWMutex
+	entries   []types.ProbeLogEntry // Reuse ProbeLogEntry type for consistency
+	maxSize   int
+	listeners map[string]chan types.ProbeLogEntry
+}
+
+// NewLogBuffer creates a new log buffer with the specified maximum size
+func NewLogBuffer(maxSize int) *LogBuffer {
+	return &LogBuffer{
+		entries:   make([]types.ProbeLogEntry, 0, maxSize),
+		maxSize:   maxSize,
+		listeners: make(map[string]chan types.ProbeLogEntry),
+	}
+}
+
+// Add adds a log entry to the buffer and broadcasts to all listeners
+func (b *LogBuffer) Add(entry types.ProbeLogEntry) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Add to buffer (keep last maxSize entries)
+	b.entries = append(b.entries, entry)
+	if len(b.entries) > b.maxSize {
+		b.entries = b.entries[len(b.entries)-b.maxSize:]
+	}
+
+	// Broadcast to all listeners (non-blocking)
+	for _, ch := range b.listeners {
+		select {
+		case ch <- entry:
+		default:
+			// Listener channel full, skip
+		}
+	}
+}
+
+// Subscribe creates a new listener channel
+func (b *LogBuffer) Subscribe(ctx context.Context, listenerID string) <-chan types.ProbeLogEntry {
+	ch := make(chan types.ProbeLogEntry, 100)
+
+	b.mu.Lock()
+	b.listeners[listenerID] = ch
+	// Send recent entries to new subscriber
+	recentEntries := make([]types.ProbeLogEntry, len(b.entries))
+	copy(recentEntries, b.entries)
+	b.mu.Unlock()
+
+	// Send recent entries in a goroutine to avoid blocking
+	go func() {
+		for _, entry := range recentEntries {
+			select {
+			case ch <- entry:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Clean up on context cancellation
+	go func() {
+		<-ctx.Done()
+		b.Unsubscribe(listenerID)
+	}()
+
+	return ch
+}
+
+// Unsubscribe removes a listener
+func (b *LogBuffer) Unsubscribe(listenerID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if ch, ok := b.listeners[listenerID]; ok {
+		close(ch)
+		delete(b.listeners, listenerID)
+	}
+}
+
+// ServerLogHandler is a custom slog.Handler that sends logs to the log buffer
+type ServerLogHandler struct {
+	logBuffer *LogBuffer
+	next      slog.Handler
+	attrs     []slog.Attr // Accumulated attributes from WithAttrs
+	groups    []string    // Accumulated group names from WithGroup
+}
+
+// NewServerLogHandler creates a new handler that sends logs to the buffer
+func NewServerLogHandler(logBuffer *LogBuffer, next slog.Handler) *ServerLogHandler {
+	return &ServerLogHandler{
+		logBuffer: logBuffer,
+		next:      next,
+		attrs:     []slog.Attr{},
+		groups:    []string{},
+	}
+}
+
+// Enabled reports whether the handler handles records at the given level
+func (h *ServerLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+// Handle handles the Record
+func (h *ServerLogHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Extract attributes including those from WithAttrs
+	attrs := make(map[string]any)
+
+	// First add accumulated attrs from WithAttrs
+	for _, attr := range h.attrs {
+		attrs[attr.Key] = attr.Value.Any()
+	}
+
+	// Then add attrs from the record
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+
+	// Add log level to attrs
+	attrs["level"] = r.Level.String()
+
+	// Add to buffer
+	h.logBuffer.Add(types.ProbeLogEntry{
+		Timestamp: r.Time,
+		Message:   r.Message,
+		Attrs:     attrs,
+	})
+
+	// Forward to next handler
+	return h.next.Handle(ctx, r)
+}
+
+// WithAttrs returns a new Handler whose attributes consist of
+// both the receiver's attributes and the arguments
+func (h *ServerLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// Accumulate attributes
+	newAttrs := make([]slog.Attr, len(h.attrs)+len(attrs))
+	copy(newAttrs, h.attrs)
+	copy(newAttrs[len(h.attrs):], attrs)
+
+	return &ServerLogHandler{
+		logBuffer: h.logBuffer,
+		next:      h.next.WithAttrs(attrs),
+		attrs:     newAttrs,
+		groups:    h.groups,
+	}
+}
+
+// WithGroup returns a new Handler with the given group appended to
+// the receiver's existing groups
+func (h *ServerLogHandler) WithGroup(name string) slog.Handler {
+	// Accumulate group names
+	newGroups := make([]string, len(h.groups)+1)
+	copy(newGroups, h.groups)
+	newGroups[len(h.groups)] = name
+
+	return &ServerLogHandler{
+		logBuffer: h.logBuffer,
+		next:      h.next.WithGroup(name),
+		attrs:     h.attrs,
+		groups:    newGroups,
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -18,30 +18,33 @@ const (
 	ViewDetail
 	ViewConfirm
 	ViewProbe
+	ViewServerLogs
 )
 
 // TUIModel represents the TUI application state
 type TUIModel struct {
-	ctx          context.Context
-	apiClient    apiclient.APIClient
-	clients      []types.ClientInfo
-	selectedIdx  int
-	viewMode     ViewMode
-	selectedID   string
-	clientDetail *types.FullClientInfo
-	confirmState *confirmState
-	probeState   *probeState
-	width        int
-	height       int
-	lastUpdate   time.Time
-	err          error
-	errorTime    time.Time
-	successMsg   string
-	successTime  time.Time
-	detailScroll int
-	listScroll   int
-	logEntries   []LogEntry // Recent log messages from slog
-	logChan      chan LogEntry
+	ctx                   context.Context
+	apiClient             apiclient.APIClient
+	clients               []types.ClientInfo
+	selectedIdx           int
+	viewMode              ViewMode
+	selectedID            string
+	clientDetail          *types.FullClientInfo
+	confirmState          *confirmState
+	probeState            *probeState
+	width                 int
+	height                int
+	lastUpdate            time.Time
+	err                   error
+	errorTime             time.Time
+	successMsg            string
+	successTime           time.Time
+	detailScroll          int
+	listScroll            int
+	logEntries            []LogEntry // Recent log messages from slog
+	logChan               chan LogEntry
+	serverLogsScroll      int // Scroll position for server logs view
+	serverLogsSelectedIdx int // Selected log index in server logs view
 }
 
 // LogEntry represents a log message

--- a/tui/model.go
+++ b/tui/model.go
@@ -196,8 +196,14 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// Auto-scroll to bottom only if auto-scroll is enabled
 			if m.probeState.autoScroll {
-				m.probeState.scroll = len(m.probeState.logs)
 				m.probeState.selectedIdx = len(m.probeState.logs) - 1 // Select the latest log
+				// Adjust scroll to show the last item
+				visibleRows := m.getProbeVisibleRows()
+				maxScroll := len(m.probeState.logs) - visibleRows
+				if maxScroll < 0 {
+					maxScroll = 0
+				}
+				m.probeState.scroll = maxScroll
 			}
 
 			// Continue listening for next log

--- a/tui/probe_test.go
+++ b/tui/probe_test.go
@@ -60,6 +60,16 @@ func (m *mockAPIClient) ReloadConfig(ctx context.Context) (*config.Config, error
 	return &config.Config{}, nil
 }
 
+func (m *mockAPIClient) StreamServerLogs(ctx context.Context) (<-chan types.ProbeLogEntry, error) {
+	ch := make(chan types.ProbeLogEntry, 10)
+	// Return empty channel for tests
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, nil
+}
+
 // Ensure mockAPIClient implements apiclient.APIClient
 var _ apiclient.APIClient = (*mockAPIClient)(nil)
 

--- a/tui/slog_handler.go
+++ b/tui/slog_handler.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TUIHandler is a custom slog.Handler that sends logs to the TUI
+type TUIHandler struct {
+	logChan chan<- LogEntry
+	next    slog.Handler
+}
+
+// NewTUIHandler creates a new TUI handler that sends logs to the given channel
+// and also forwards to the next handler (for console output)
+func NewTUIHandler(logChan chan<- LogEntry, next slog.Handler) *TUIHandler {
+	return &TUIHandler{
+		logChan: logChan,
+		next:    next,
+	}
+}
+
+// Enabled reports whether the handler handles records at the given level
+func (h *TUIHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+// Handle handles the Record
+func (h *TUIHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Extract attributes
+	attrs := make(map[string]any)
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+
+	// Send to TUI channel (non-blocking)
+	select {
+	case h.logChan <- LogEntry{
+		Time:    r.Time,
+		Level:   r.Level.String(),
+		Message: r.Message,
+		Attrs:   attrs,
+	}:
+	default:
+		// Channel full, skip this log to avoid blocking
+	}
+
+	// Forward to next handler
+	return h.next.Handle(ctx, r)
+}
+
+// WithAttrs returns a new Handler whose attributes consist of
+// both the receiver's attributes and the arguments
+func (h *TUIHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &TUIHandler{
+		logChan: h.logChan,
+		next:    h.next.WithAttrs(attrs),
+	}
+}
+
+// WithGroup returns a new Handler with the given group appended to
+// the receiver's existing groups
+func (h *TUIHandler) WithGroup(name string) slog.Handler {
+	return &TUIHandler{
+		logChan: h.logChan,
+		next:    h.next.WithGroup(name),
+	}
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -217,6 +217,21 @@ func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Stop probe stream and return to list view
 		m.stopProbeStream()
 		m.viewMode = ViewList
+	case " ":
+		// Toggle auto-scroll with space key
+		if m.probeState != nil {
+			m.probeState.autoScroll = !m.probeState.autoScroll
+			// If enabling auto-scroll, jump to bottom
+			if m.probeState.autoScroll && len(m.probeState.logs) > 0 {
+				m.probeState.selectedIdx = len(m.probeState.logs) - 1
+				visibleRows := m.getProbeVisibleRows()
+				maxScroll := len(m.probeState.logs) - visibleRows
+				if maxScroll < 0 {
+					maxScroll = 0
+				}
+				m.probeState.scroll = maxScroll
+			}
+		}
 	case "up", "k":
 		if m.probeState != nil && len(m.probeState.logs) > 0 {
 			if m.probeState.selectedIdx > 0 {

--- a/tui/view.go
+++ b/tui/view.go
@@ -449,9 +449,13 @@ func (m *TUIModel) renderProbeView() string {
 
 	// Help text
 	b.WriteString("\n")
-	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • PgUp/PgDn page"
-	if m.probeState != nil && !m.probeState.autoScroll {
-		helpText += " • Auto-scroll: OFF (press End to re-enable)"
+	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • PgUp/PgDn page • SPACE pause"
+	if m.probeState != nil {
+		if m.probeState.autoScroll {
+			helpText += " • Auto-scroll: ON"
+		} else {
+			helpText += " • Auto-scroll: OFF"
+		}
 	}
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(helpText))
 

--- a/tui/view.go
+++ b/tui/view.go
@@ -48,6 +48,8 @@ func (m *TUIModel) View() string {
 		return m.renderProbeView()
 	case ViewServerLogs:
 		return m.renderServerLogsView()
+	case ViewSaveConfirm:
+		return m.renderSaveConfirmView()
 	default:
 		return "Unknown view"
 	}
@@ -449,7 +451,7 @@ func (m *TUIModel) renderProbeView() string {
 
 	// Help text
 	b.WriteString("\n")
-	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • PgUp/PgDn page • SPACE pause"
+	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • PgUp/PgDn page • SPACE pause • s save"
 	if m.probeState != nil {
 		if m.probeState.autoScroll {
 			helpText += " • Auto-scroll: ON"
@@ -764,6 +766,47 @@ func (m *TUIModel) renderServerLogsView() string {
 	b.WriteString("\n")
 	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • PgUp/PgDn page"
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(helpText))
+
+	return b.String()
+}
+
+// renderSaveConfirmView renders the save file confirmation view
+func (m *TUIModel) renderSaveConfirmView() string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Render("Save Probe Logs to File"))
+	b.WriteString("\n\n")
+
+	if m.saveState == nil {
+		return "Error: save state not initialized"
+	}
+
+	// Show file path with editing capability
+	b.WriteString("File path: ")
+	if m.saveState.editing {
+		// Show cursor when editing
+		before := m.saveState.filePath[:m.saveState.cursorPos]
+		after := m.saveState.filePath[m.saveState.cursorPos:]
+		cursor := lipgloss.NewStyle().Background(lipgloss.Color("255")).Foreground(lipgloss.Color("0")).Render(" ")
+		b.WriteString(before + cursor + after)
+	} else {
+		b.WriteString(m.saveState.filePath)
+	}
+	b.WriteString("\n\n")
+
+	// Show log count
+	if m.probeState != nil {
+		b.WriteString(fmt.Sprintf("Logs to save: %d entries\n\n", len(m.probeState.logs)))
+	}
+
+	// Help text
+	if m.saveState.editing {
+		helpText := "Type to edit path • ESC to stop editing • ENTER to confirm"
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(helpText))
+	} else {
+		helpText := "ENTER to save • e to edit path • ESC/n to cancel"
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(helpText))
+	}
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary
- Improve probe log display with JSON format and text wrapping
- Add server log streaming to TUI with dedicated view
- Add pause functionality to probe log view
- Add file save functionality to probe log view
- Update README with new TUI features

## Changes

### Probe Log Display Improvements
- Change attribute display from key=value format to JSON format (matching CLI output)
- Remove 100-character truncation limit
- Implement text wrapping for long lines to fit screen width
- Apply proper styling to wrapped lines

### Server Log Streaming
- Add `LogBuffer` and `ServerLogHandler` for capturing server logs
- Implement SSE endpoint `GET /logs` for streaming server logs
- Add `StreamServerLogs()` to apiclient interface
- Forward server logs to TUI in real-time
- Include structured attributes from `WithAttrs()` calls
- Display server logs in dedicated full-screen view (press 'l' key)

### Pause Functionality
- Add SPACE key to toggle auto-scroll on/off in probe view
- Fix auto-scroll scroll position calculation
- Display auto-scroll status (ON/OFF) in help text
- Auto-scroll disabled when manually scrolling up

### File Save Functionality
- Press 's' key to open save confirmation dialog
- Default filename format: `{clientID}-{timestamp}.log`
- Edit file path with 'e' key (supports cursor navigation, insert, delete)
- Save logs in JSON Lines format
- Return to probe view after successful save

### Documentation
- Update README with all new TUI features
- Document navigation keys and functionality

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [x] Probe log JSON format displays correctly without truncation
- [x] Text wrapping works for long lines
- [x] Server logs stream correctly to TUI
- [x] Server log attributes captured properly
- [x] Pause functionality (SPACE key) works correctly
- [x] File save dialog and editing works
- [x] Logs saved in correct JSON Lines format

🤖 Generated with [Claude Code](https://claude.com/claude-code)