### PR TITLE
Rename ReadTimeout to HandshakeTimeout and separate process timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ trabbit's configuration file is located at `config.json`. The configuration file
 
 ```json
 {
-    "read_timeout": "5s",
+    "handshake_timeout": "5s",
     "connection_close_timeout": "1s",
     "upstreams": [
         {
@@ -228,10 +228,10 @@ If the routing key does not match any patterns, trabbits will use the first upst
 
 These timeout settings control internal connection behavior and typically do not need to be modified:
 
-- `read_timeout`: (Optional) Maximum time to wait for reading data from client connections (default: 5s). Accepts Go duration format (e.g., "5s", "10s").
+- `handshake_timeout`: (Optional) Maximum time to wait for each frame during the AMQP handshake process (Connection.Start-Ok, Connection.Tune-Ok, Connection.Open) from client connections (default: 5s). Accepts Go duration format (e.g., "5s", "10s").
 - `connection_close_timeout`: (Optional) Maximum time to wait for Connection.Close-Ok response during graceful connection shutdown (default: 1s). Accepts Go duration format.
 
-**Note:** These are advanced settings that should only be adjusted if you experience specific timeout-related issues. The default values are suitable for most use cases.
+**Note:** These are advanced settings that should only be adjusted if you experience specific timeout-related issues. The default values are suitable for most use cases. Normal message processing uses a longer fixed timeout (5 minutes) to accommodate low-frequency client communication patterns.
 
 #### Graceful Shutdown Settings
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const (
 // Config represents the configuration of the trabbits proxy.
 type Config struct {
 	Upstreams              []Upstream       `yaml:"upstreams" json:"upstreams"`
-	ReadTimeout            Duration         `yaml:"read_timeout,omitempty" json:"read_timeout,omitempty"`
+	HandshakeTimeout       Duration         `yaml:"handshake_timeout,omitempty" json:"handshake_timeout,omitempty"`
 	ConnectionCloseTimeout Duration         `yaml:"connection_close_timeout,omitempty" json:"connection_close_timeout,omitempty"`
 	GracefulShutdown       GracefulShutdown `yaml:"graceful_shutdown,omitempty" json:"graceful_shutdown,omitempty"`
 }
@@ -102,8 +102,8 @@ func Load(ctx context.Context, f string) (*Config, error) {
 // SetDefaults sets default values for config fields if not specified
 func (c *Config) SetDefaults() {
 	// Set default timeout values if not specified
-	if c.ReadTimeout == 0 {
-		c.ReadTimeout = Duration(5 * time.Second) // DefaultReadTimeout
+	if c.HandshakeTimeout == 0 {
+		c.HandshakeTimeout = Duration(5 * time.Second) // DefaultHandshakeTimeout
 	}
 	if c.ConnectionCloseTimeout == 0 {
 		c.ConnectionCloseTimeout = Duration(1 * time.Second) // DefaultConnectionCloseTimeout

--- a/handshake_timeout_test.go
+++ b/handshake_timeout_test.go
@@ -1,0 +1,52 @@
+// MIT License
+// Copyright (c) 2025 FUJIWARA Shunichiro
+
+package trabbits_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestHandshakeTimeout(t *testing.T) {
+	addr := fmt.Sprintf("localhost:%d", testProxyPort)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Failed to connect to test server: %v", err)
+	}
+	defer conn.Close()
+
+	time.Sleep(1500 * time.Millisecond) // Wait longer than the handshake timeout
+	_, err = conn.Read(make([]byte, 1))
+	if err == nil {
+		t.Fatal("Expected connection to be closed by server, but read succeeded")
+	}
+	t.Logf("Connection closed as expected: %v", err)
+}
+
+func TestHandshakeTimeoutAfterAMQPHeader(t *testing.T) {
+	addr := fmt.Sprintf("localhost:%d", testProxyPort)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Failed to connect to test server: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("AMQP\x00\x00\x09\x01")); err != nil {
+		t.Fatalf("Failed to send AMQP header: %v", err)
+	}
+	buf := make([]byte, 1024) // ensure buffer is large enough for amqp header response
+	if n, err := conn.Read(buf); err != nil {
+		t.Fatalf("Failed to read from server: %v", err)
+	} else {
+		t.Logf("Received %d bytes from server after sending AMQP header", n)
+	}
+
+	time.Sleep(1500 * time.Millisecond) // Wait longer than the handshake timeout
+	_, err = conn.Read(buf)
+	if err == nil {
+		t.Fatal("Expected connection to be closed by server, but Read succeeded")
+	}
+	t.Logf("Connection closed as expected: %v", err)
+}

--- a/testdata/config.json
+++ b/testdata/config.json
@@ -1,5 +1,5 @@
 {
-    "read_timeout": "5s",
+    "handshake_timeout": "1s",
     "connection_close_timeout": "1s",
     "upstreams": [
         {


### PR DESCRIPTION
## Summary

- Rename `ReadTimeout` to `HandshakeTimeout` for clarity of purpose
- Separate handshake and process timeouts with different values
- Add handshake timeout enforcement at connection start
- Add comprehensive tests for handshake timeout behavior

## Changes

### Configuration
- Renamed `read_timeout` to `handshake_timeout` in configuration (breaking change)
- Default: 5 seconds (configurable)
- Purpose: Timeout for AMQP handshake phase to prevent slowloris-type attacks

### Timeout Separation
- **Handshake timeout**: Short timeout (default 5s, configurable) used during AMQP handshake
- **Process timeout**: Long fixed timeout (5 minutes) used during normal message processing
- This prevents unnecessary timeout loops for low-frequency clients while maintaining security

### Implementation
- Added `handshakeTimeout` and `processTimeout` fields to Proxy struct
- Modified `readClientFrame()` to use process timeout by default
- Added `readClientFrameWithTimeout()` for explicit timeout control
- Modified `recv()` to use process timeout, `recvWithTimeout()` for handshake
- Set read deadline at connection start in `handleConnection()`

### Tests
- Added `TestHandshakeTimeout`: Verifies timeout when client doesn't send AMQP header
- Added `TestHandshakeTimeoutAfterAMQPHeader`: Verifies timeout after AMQP header but before Connection.Start-Ok

### Documentation
- Updated README to clarify the purpose of `handshake_timeout`
- Explained that normal message processing uses a longer fixed timeout

## Motivation

Previously, `ReadTimeout` was used for all read operations, causing:
1. **Security risk**: No specific timeout for handshake phase allowed slowloris attacks
2. **Inefficiency**: Low-frequency clients triggered timeout→retry loops every 5 seconds during normal operation

This change addresses both issues by using appropriate timeouts for different phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)