### PR TITLE
Improve TUI log display and refresh rate

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -189,18 +189,15 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKeyPress(msg)
 
 	case tickMsg:
-		if time.Since(m.lastUpdate) > 2*time.Second {
-			// Always fetch clients list
-			cmds := []tea.Cmd{m.fetchClients(), tick()}
+		// Always fetch clients list on every tick (every 2 seconds)
+		cmds := []tea.Cmd{m.fetchClients(), tick()}
 
-			// If in detail view, also fetch updated client detail
-			if m.viewMode == ViewDetail && m.clientDetail != nil {
-				cmds = append(cmds, m.fetchClientDetail(m.clientDetail.ID))
-			}
-
-			return m, tea.Batch(cmds...)
+		// If in detail view, also fetch updated client detail
+		if m.viewMode == ViewDetail && m.clientDetail != nil {
+			cmds = append(cmds, m.fetchClientDetail(m.clientDetail.ID))
 		}
-		return m, tick()
+
+		return m, tea.Batch(cmds...)
 
 	case clientsMsg:
 		// Preserve selection by client ID when possible

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -392,7 +392,14 @@ func (m *TUIModel) updateAutoScroll() {
 // getProbeVisibleRows calculates visible rows for probe logs
 func (m *TUIModel) getProbeVisibleRows() int {
 	// Reserve space for header, footer, and status
-	return m.height - 6
+	// Header: title (2 lines), status (2 lines)
+	// Footer: help (2 lines), error/success (2 lines)
+	reserved := 8
+	visible := m.height - reserved
+	if visible < 5 {
+		visible = 5
+	}
+	return visible
 }
 
 // handleServerLogsKeys handles keys in the server logs view

--- a/tui/view.go
+++ b/tui/view.go
@@ -428,140 +428,33 @@ func (m *TUIModel) renderProbeView() string {
 		}
 	} else {
 		maxDisplayLines := m.getProbeVisibleRows()
-		startIdx := m.probeState.scroll
-		if startIdx < 0 {
-			startIdx = 0
-		}
-		if startIdx >= logCount {
-			startIdx = logCount - 1
-		}
-		if startIdx < 0 {
-			startIdx = 0
-		}
 
-		// Calculate how many log entries we can display within maxDisplayLines
-		// while ensuring the selected entry is visible
-		selectedIdx := m.probeState.selectedIdx
-		if selectedIdx < 0 {
-			selectedIdx = 0
-		}
-		if selectedIdx >= logCount {
-			selectedIdx = logCount - 1
-		}
-
-		// If selected is before startIdx, adjust startIdx to show selected
-		if selectedIdx < startIdx {
-			startIdx = selectedIdx
-		}
-
-		// Render logs from startIdx, counting actual display lines
-		var renderedLogs []string
-		var renderedIndices []int
-		displayLines := 0
-		endIdx := startIdx
-
-		for i := startIdx; i < logCount && displayLines < maxDisplayLines; i++ {
-			log := m.probeState.logs[i]
-			logLine := m.formatProbeLogLine(log)
-			lineCount := strings.Count(logLine, "\n") + 1
-
-			// If adding this entry would exceed available space, stop unless it's the selected entry
-			if displayLines+lineCount > maxDisplayLines && i != selectedIdx {
-				// If we haven't reached the selected entry yet, we need to adjust
-				if selectedIdx > i {
-					// Skip this entry and continue to reach selected
-					continue
-				}
-				break
-			}
-
-			// Highlight selected entry
-			if i == selectedIdx {
-				logLine = selectedStyle.Render(logLine)
-			}
-
-			renderedLogs = append(renderedLogs, logLine)
-			renderedIndices = append(renderedIndices, i)
-			displayLines += lineCount
-			endIdx = i + 1
-		}
-
-		// If we didn't render the selected entry, adjust startIdx and retry
-		selectedRendered := false
-		for _, idx := range renderedIndices {
-			if idx == selectedIdx {
-				selectedRendered = true
-				break
-			}
-		}
-
-		if !selectedRendered && selectedIdx < logCount {
-			// Start from selected entry and render backwards/forwards to fill screen
-			renderedLogs = []string{}
-			renderedIndices = []int{}
-			displayLines = 0
-
-			// First, render the selected entry
-			log := m.probeState.logs[selectedIdx]
-			logLine := m.formatProbeLogLine(log)
-			logLine = selectedStyle.Render(logLine)
-			lineCount := strings.Count(logLine, "\n") + 1
-
-			renderedLogs = append(renderedLogs, logLine)
-			renderedIndices = append(renderedIndices, selectedIdx)
-			displayLines += lineCount
-
-			// Try to add entries after selected
-			for i := selectedIdx + 1; i < logCount && displayLines < maxDisplayLines; i++ {
-				log := m.probeState.logs[i]
+		// Use common rendering function
+		result := renderLogsWithWrapping(
+			logCount,
+			maxDisplayLines,
+			m.probeState.scroll,
+			m.probeState.selectedIdx,
+			func(idx int, isSelected bool) string {
+				log := m.probeState.logs[idx]
 				logLine := m.formatProbeLogLine(log)
-				lineCount := strings.Count(logLine, "\n") + 1
-
-				if displayLines+lineCount > maxDisplayLines {
-					break
+				if isSelected {
+					logLine = selectedStyle.Render(logLine)
 				}
-
-				renderedLogs = append(renderedLogs, logLine)
-				renderedIndices = append(renderedIndices, i)
-				displayLines += lineCount
-			}
-
-			// Try to add entries before selected
-			var beforeLogs []string
-			var beforeIndices []int
-			for i := selectedIdx - 1; i >= 0 && displayLines < maxDisplayLines; i-- {
-				log := m.probeState.logs[i]
-				logLine := m.formatProbeLogLine(log)
-				lineCount := strings.Count(logLine, "\n") + 1
-
-				if displayLines+lineCount > maxDisplayLines {
-					break
-				}
-
-				beforeLogs = append([]string{logLine}, beforeLogs...)
-				beforeIndices = append([]int{i}, beforeIndices...)
-				displayLines += lineCount
-			}
-
-			renderedLogs = append(beforeLogs, renderedLogs...)
-			renderedIndices = append(beforeIndices, renderedIndices...)
-
-			if len(renderedIndices) > 0 {
-				startIdx = renderedIndices[0]
-				endIdx = renderedIndices[len(renderedIndices)-1] + 1
-			}
-		}
+				return logLine
+			},
+		)
 
 		// Write rendered logs
-		for _, logLine := range renderedLogs {
+		for _, logLine := range result.renderedLines {
 			b.WriteString(logLine)
 			b.WriteString("\n")
 		}
 
 		// Add scroll indicator
-		if logCount > len(renderedIndices) {
+		if logCount > len(result.renderedLines) {
 			scrollInfo := fmt.Sprintf(" [%d-%d of %d logs]",
-				startIdx+1, endIdx, logCount)
+				result.startIdx+1, result.endIdx, logCount)
 			b.WriteString("\n" + scrollInfoStyle.Render(scrollInfo))
 		}
 	}
@@ -648,6 +541,151 @@ func (m *TUIModel) formatProbeLogLine(log probeLogEntry) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// renderResult holds the result of rendering logs with line wrapping
+type renderResult struct {
+	renderedLines []string // formatted and styled log lines ready to display
+	startIdx      int      // first log entry index in the result
+	endIdx        int      // last log entry index + 1 in the result
+}
+
+// renderLogsWithWrapping renders log entries accounting for line wrapping,
+// ensuring the selected entry is always visible within maxDisplayLines.
+// formatFunc should return the formatted (and optionally styled) log line for a given index.
+func renderLogsWithWrapping(
+	logCount int,
+	maxDisplayLines int,
+	scrollPos int,
+	selectedIdx int,
+	formatFunc func(idx int, isSelected bool) string,
+) renderResult {
+	if logCount == 0 {
+		return renderResult{}
+	}
+
+	// Clamp inputs
+	startIdx := scrollPos
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	if startIdx >= logCount {
+		startIdx = logCount - 1
+	}
+	if startIdx < 0 {
+		startIdx = 0
+	}
+
+	if selectedIdx < 0 {
+		selectedIdx = 0
+	}
+	if selectedIdx >= logCount {
+		selectedIdx = logCount - 1
+	}
+
+	// If selected is before startIdx, adjust startIdx to show selected
+	if selectedIdx < startIdx {
+		startIdx = selectedIdx
+	}
+
+	// Render logs from startIdx, counting actual display lines
+	var renderedLines []string
+	var renderedIndices []int
+	displayLines := 0
+	endIdx := startIdx
+
+	for i := startIdx; i < logCount && displayLines < maxDisplayLines; i++ {
+		logLine := formatFunc(i, false)
+		lineCount := strings.Count(logLine, "\n") + 1
+
+		// If adding this entry would exceed available space, stop unless it's the selected entry
+		if displayLines+lineCount > maxDisplayLines && i != selectedIdx {
+			// If we haven't reached the selected entry yet, we need to adjust
+			if selectedIdx > i {
+				// Skip this entry and continue to reach selected
+				continue
+			}
+			break
+		}
+
+		// Re-format with selection styling if this is the selected entry
+		if i == selectedIdx {
+			logLine = formatFunc(i, true)
+		}
+
+		renderedLines = append(renderedLines, logLine)
+		renderedIndices = append(renderedIndices, i)
+		displayLines += lineCount
+		endIdx = i + 1
+	}
+
+	// If we didn't render the selected entry, adjust startIdx and retry
+	selectedRendered := false
+	for _, idx := range renderedIndices {
+		if idx == selectedIdx {
+			selectedRendered = true
+			break
+		}
+	}
+
+	if !selectedRendered && selectedIdx < logCount {
+		// Start from selected entry and render backwards/forwards to fill screen
+		renderedLines = []string{}
+		renderedIndices = []int{}
+		displayLines = 0
+
+		// First, render the selected entry
+		logLine := formatFunc(selectedIdx, true)
+		lineCount := strings.Count(logLine, "\n") + 1
+
+		renderedLines = append(renderedLines, logLine)
+		renderedIndices = append(renderedIndices, selectedIdx)
+		displayLines += lineCount
+
+		// Try to add entries after selected
+		for i := selectedIdx + 1; i < logCount && displayLines < maxDisplayLines; i++ {
+			logLine := formatFunc(i, false)
+			lineCount := strings.Count(logLine, "\n") + 1
+
+			if displayLines+lineCount > maxDisplayLines {
+				break
+			}
+
+			renderedLines = append(renderedLines, logLine)
+			renderedIndices = append(renderedIndices, i)
+			displayLines += lineCount
+		}
+
+		// Try to add entries before selected
+		var beforeLines []string
+		var beforeIndices []int
+		for i := selectedIdx - 1; i >= 0 && displayLines < maxDisplayLines; i-- {
+			logLine := formatFunc(i, false)
+			lineCount := strings.Count(logLine, "\n") + 1
+
+			if displayLines+lineCount > maxDisplayLines {
+				break
+			}
+
+			beforeLines = append([]string{logLine}, beforeLines...)
+			beforeIndices = append([]int{i}, beforeIndices...)
+			displayLines += lineCount
+		}
+
+		renderedLines = append(beforeLines, renderedLines...)
+		renderedIndices = append(beforeIndices, renderedIndices...)
+
+		if len(renderedIndices) > 0 {
+			startIdx = renderedIndices[0]
+			endIdx = renderedIndices[len(renderedIndices)-1] + 1
+		}
+	}
+
+	return renderResult{
+		renderedLines: renderedLines,
+		startIdx:      startIdx,
+		endIdx:        endIdx,
+	}
 }
 
 // wrapText wraps text to the specified width, returning a slice of lines
@@ -823,41 +861,35 @@ func (m *TUIModel) renderServerLogsView() string {
 	if len(m.logEntries) == 0 {
 		b.WriteString("No server logs yet...\n")
 	} else {
-		visibleRows := m.getServerLogsVisibleRows()
-		startIdx := m.serverLogsScroll
-		if startIdx < 0 {
-			startIdx = 0
-		}
-		maxScroll := len(m.logEntries) - visibleRows
-		if maxScroll < 0 {
-			maxScroll = 0
-		}
-		if startIdx > maxScroll {
-			startIdx = maxScroll
-		}
-		endIdx := startIdx + visibleRows
-		if endIdx > len(m.logEntries) {
-			endIdx = len(m.logEntries)
-		}
+		logCount := len(m.logEntries)
+		maxDisplayLines := m.getServerLogsVisibleRows()
 
-		// Render visible logs
-		for i := startIdx; i < endIdx; i++ {
-			entry := m.logEntries[i]
-			logLine := m.formatLogEntry(entry)
+		// Use common rendering function
+		result := renderLogsWithWrapping(
+			logCount,
+			maxDisplayLines,
+			m.serverLogsScroll,
+			m.serverLogsSelectedIdx,
+			func(idx int, isSelected bool) string {
+				entry := m.logEntries[idx]
+				logLine := m.formatLogEntry(entry)
+				if isSelected {
+					logLine = selectedStyle.Render(logLine)
+				}
+				return logLine
+			},
+		)
 
-			// Highlight selected line
-			if i == m.serverLogsSelectedIdx {
-				logLine = selectedStyle.Render(logLine)
-			}
-
+		// Write rendered logs
+		for _, logLine := range result.renderedLines {
 			b.WriteString(logLine)
 			b.WriteString("\n")
 		}
 
 		// Add scroll indicator
-		if len(m.logEntries) > visibleRows {
+		if logCount > len(result.renderedLines) {
 			scrollInfo := fmt.Sprintf(" [%d-%d of %d logs]",
-				startIdx+1, endIdx, len(m.logEntries))
+				result.startIdx+1, result.endIdx, logCount)
 			scrollStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 			b.WriteString("\n" + scrollStyle.Render(scrollInfo))
 		}

--- a/tui/view.go
+++ b/tui/view.go
@@ -395,20 +395,13 @@ func (m *TUIModel) renderProbeView() string {
 	b.WriteString(headerStyle.Render(headerText))
 	b.WriteString("\n\n")
 
-	// Show log count
+	// Show log count (keep it short to avoid wrapping)
 	logCount := len(m.probeState.logs)
-	statusText := fmt.Sprintf("Total logs: %d", logCount)
+	statusText := fmt.Sprintf("Logs: %d", logCount)
 	if logCount > 0 {
 		latest := m.probeState.logs[logCount-1]
-		statusText += fmt.Sprintf(" • Latest: %s", latest.Timestamp.Format("15:04:05.000"))
+		statusText += fmt.Sprintf(" • Latest: %s", latest.Timestamp.Format("15:04:05"))
 	}
-	// Debug: Show scroll position
-	visibleRows := m.getProbeVisibleRows()
-	maxScroll := logCount - visibleRows
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
-	statusText += fmt.Sprintf(" • Scroll: %d/%d (visible: %d)", m.probeState.scroll, maxScroll, visibleRows)
 	b.WriteString(statusDimStyle.Render(statusText))
 	b.WriteString("\n\n")
 

--- a/tui/view.go
+++ b/tui/view.go
@@ -551,6 +551,7 @@ func (m *TUIModel) formatProbeLogLine(log probeLogEntry) string {
 }
 
 // wrapText wraps text to the specified width, returning a slice of lines
+// Text is wrapped at the right edge regardless of character type (no word wrapping)
 func wrapText(text string, width int) []string {
 	if width <= 0 {
 		return []string{text}
@@ -568,53 +569,23 @@ func wrapText(text string, width int) []string {
 		runes := []rune(seg)
 		start := 0
 		lineWidth := 0
-		lastSpace := -1
-		i := 0
-		for i < len(runes) {
+
+		for i := 0; i < len(runes); i++ {
 			ch := runes[i]
-			if ch == '\n' {
-				out = append(out, string(runes[start:i]))
-				start = i + 1
-				lineWidth = 0
-				lastSpace = -1
-				i++
-				continue
-			}
-
 			rw := runewidth.RuneWidth(ch)
-			if ch == ' ' {
-				lastSpace = i
-			}
 
-			// If adding this rune would exceed width, wrap
+			// If adding this rune would exceed width, wrap here
 			if lineWidth+rw > width {
-				if lastSpace >= start {
-					// Wrap at last space; next line starts after the space
-					out = append(out, string(runes[start:lastSpace]))
-					start = lastSpace + 1
-					// Reset to after space and recompute width from that position
-					lineWidth = 0
-					for j := start; j < i; j++ {
-						lineWidth += runewidth.RuneWidth(runes[j])
-					}
-					lastSpace = -1
-					continue
-				}
-				// No space to break at; hard wrap before this rune
-				if i > start {
-					out = append(out, string(runes[start:i]))
-					start = i
-					lineWidth = 0
-					lastSpace = -1
-					continue
-				}
+				out = append(out, string(runes[start:i]))
+				start = i
+				lineWidth = 0
 			}
 
 			lineWidth += rw
-			i++
 		}
+
 		// Flush remainder
-		if start <= len(runes) {
+		if start < len(runes) {
 			out = append(out, string(runes[start:]))
 		}
 	}

--- a/tui/view_test.go
+++ b/tui/view_test.go
@@ -1,0 +1,211 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestRenderLogsWithWrapping tests the common log rendering logic
+func TestRenderLogsWithWrapping(t *testing.T) {
+	tests := []struct {
+		name            string
+		logCount        int
+		maxDisplayLines int
+		scrollPos       int
+		selectedIdx     int
+		logLines        []string // each entry can be multi-line
+		wantStartIdx    int
+		wantEndIdx      int
+		wantSelected    int // index in renderedLines that should be selected (-1 if none)
+	}{
+		{
+			name:            "simple case - all fit",
+			logCount:        3,
+			maxDisplayLines: 10,
+			scrollPos:       0,
+			selectedIdx:     1,
+			logLines:        []string{"log 0", "log 1", "log 2"},
+			wantStartIdx:    0,
+			wantEndIdx:      3,
+			wantSelected:    1,
+		},
+		{
+			name:            "selected entry forced visible from beginning",
+			logCount:        5,
+			maxDisplayLines: 3,
+			scrollPos:       0,
+			selectedIdx:     4,
+			logLines:        []string{"log 0", "log 1", "log 2", "log 3", "log 4"},
+			wantStartIdx:    2, // should center around selected
+			wantEndIdx:      5,
+			wantSelected:    2, // selected is at index 2 in rendered output
+		},
+		{
+			name:            "wrapped logs - selected visible",
+			logCount:        3,
+			maxDisplayLines: 5,
+			scrollPos:       0,
+			selectedIdx:     1,
+			logLines: []string{
+				"short",
+				"line1\nline2\nline3", // 3 lines
+				"another",
+			},
+			wantStartIdx: 0,
+			wantEndIdx:   3,
+			wantSelected: 1, // all should fit
+		},
+		{
+			name:            "wrapped logs exceed space - selected still visible",
+			logCount:        3,
+			maxDisplayLines: 4,
+			scrollPos:       0,
+			selectedIdx:     2, // select the last one
+			logLines: []string{
+				"short",
+				"line1\nline2\nline3", // 3 lines - would exceed if included
+				"selected",            // 1 line
+			},
+			wantStartIdx: 1, // should skip first to show selected
+			wantEndIdx:   3,
+			wantSelected: 1,
+		},
+		{
+			name:            "selected before scrollPos",
+			logCount:        10,
+			maxDisplayLines: 5,
+			scrollPos:       5,
+			selectedIdx:     2,
+			logLines:        makeSimpleLogs(10),
+			wantStartIdx:    2, // should adjust to show selected
+			wantEndIdx:      7,
+			wantSelected:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatFunc := func(idx int, isSelected bool) string {
+				line := tt.logLines[idx]
+				if isSelected {
+					return "[SELECTED] " + line
+				}
+				return line
+			}
+
+			result := renderLogsWithWrapping(
+				tt.logCount,
+				tt.maxDisplayLines,
+				tt.scrollPos,
+				tt.selectedIdx,
+				formatFunc,
+			)
+
+			if result.startIdx != tt.wantStartIdx {
+				t.Errorf("startIdx = %d, want %d", result.startIdx, tt.wantStartIdx)
+			}
+			if result.endIdx != tt.wantEndIdx {
+				t.Errorf("endIdx = %d, want %d", result.endIdx, tt.wantEndIdx)
+			}
+
+			// Check that selected entry is present and marked
+			if tt.wantSelected >= 0 {
+				if tt.wantSelected >= len(result.renderedLines) {
+					t.Fatalf("wantSelected %d >= len(renderedLines) %d", tt.wantSelected, len(result.renderedLines))
+				}
+				selectedLine := result.renderedLines[tt.wantSelected]
+				if !strings.Contains(selectedLine, "[SELECTED]") {
+					t.Errorf("renderedLines[%d] should contain [SELECTED], got: %s", tt.wantSelected, selectedLine)
+				}
+			}
+
+			// Check that total display lines don't exceed maxDisplayLines
+			totalLines := 0
+			for _, line := range result.renderedLines {
+				totalLines += strings.Count(line, "\n") + 1
+			}
+			if totalLines > tt.maxDisplayLines {
+				t.Errorf("totalLines = %d, exceeds maxDisplayLines = %d", totalLines, tt.maxDisplayLines)
+			}
+		})
+	}
+}
+
+func makeSimpleLogs(count int) []string {
+	logs := make([]string, count)
+	for i := 0; i < count; i++ {
+		logs[i] = fmt.Sprintf("log %d", i)
+	}
+	return logs
+}
+
+func TestRenderLogsWithWrapping_EmptyLogs(t *testing.T) {
+	result := renderLogsWithWrapping(0, 10, 0, 0, func(idx int, isSelected bool) string {
+		return "should not be called"
+	})
+
+	if len(result.renderedLines) != 0 {
+		t.Errorf("expected no rendered lines for empty logs, got %d", len(result.renderedLines))
+	}
+}
+
+func TestRenderLogsWithWrapping_SingleLongEntry(t *testing.T) {
+	// A single log entry that spans multiple lines
+	longLog := strings.Repeat("x", 100) + "\n" + strings.Repeat("y", 100) + "\n" + strings.Repeat("z", 100)
+
+	formatFunc := func(idx int, isSelected bool) string {
+		if isSelected {
+			return "[SEL] " + longLog
+		}
+		return longLog
+	}
+
+	result := renderLogsWithWrapping(1, 5, 0, 0, formatFunc)
+
+	if len(result.renderedLines) != 1 {
+		t.Errorf("expected 1 rendered line, got %d", len(result.renderedLines))
+	}
+
+	// Even if it exceeds maxDisplayLines, the selected entry should be shown
+	if !strings.Contains(result.renderedLines[0], "[SEL]") {
+		t.Errorf("selected entry should be marked, got: %s", result.renderedLines[0])
+	}
+}
+
+func TestRenderLogsWithWrapping_SelectedInMiddle(t *testing.T) {
+	// 10 logs, select middle one, limited display space
+	logCount := 10
+	maxDisplayLines := 5
+	selectedIdx := 5
+
+	formatFunc := func(idx int, isSelected bool) string {
+		if isSelected {
+			return fmt.Sprintf("[SEL] log %d", idx)
+		}
+		return fmt.Sprintf("log %d", idx)
+	}
+
+	result := renderLogsWithWrapping(logCount, maxDisplayLines, 0, selectedIdx, formatFunc)
+
+	// Selected should be visible
+	selectedFound := false
+	for _, line := range result.renderedLines {
+		if strings.Contains(line, "[SEL]") {
+			selectedFound = true
+			break
+		}
+	}
+
+	if !selectedFound {
+		t.Errorf("selected entry not found in rendered output")
+	}
+
+	// Should render entries around the selected one
+	if result.startIdx > selectedIdx {
+		t.Errorf("startIdx %d should be <= selectedIdx %d", result.startIdx, selectedIdx)
+	}
+	if result.endIdx <= selectedIdx {
+		t.Errorf("endIdx %d should be > selectedIdx %d", result.endIdx, selectedIdx)
+	}
+}


### PR DESCRIPTION
## Summary
- Remove word wrapping in favor of hard wrapping at screen edge for log displays
- Fix probe log and server log views to keep selected entries visible when logs wrap to multiple lines
- Extract common log rendering logic and add comprehensive tests
- Fix server logs selection background color consistency
- Improve probe log header visibility
- Update client list refresh interval from 4 seconds to 2 seconds

## Changes
### Text Wrapping
- Remove space-based word wrapping logic from `wrapText()` function
- Logs now wrap at screen edge regardless of character type, making them easier to read

### Scrolling and Selection Visibility
- Add `renderLogsWithWrapping()` function to handle multi-line log entries correctly
- Selected entries now remain visible even when they span multiple lines
- Calculate actual display lines accounting for line wrapping

### Code Quality
- Extract duplicate log rendering code from probe and server logs views into shared function
- Add comprehensive test coverage for log rendering with wrapping scenarios
- Fix selection background color in server logs to apply consistently across all parts

### UI Improvements  
- Shorten probe log status text to prevent wrapping
- Increase reserved space for headers/footers from 6 to 8 lines
- Fix client list refresh to actually update every 2 seconds instead of 4

## Test Plan
- All existing tests pass
- New tests added for `renderLogsWithWrapping()` covering:
  - Simple cases where all entries fit
  - Scrolling with selected entry forced visible
  - Wrapped logs with selection visibility
  - Edge cases (empty logs, single long entry, selected in middle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)