### PR TITLE
Send server properties in Connection.Start

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 permissions:
   contents: read
   pull-requests: write

--- a/proxy.go
+++ b/proxy.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -373,13 +374,29 @@ func (p *Proxy) newUpstream(conn *rabbitmq.Connection, conf config.Upstream, add
 	return NewUpstream(conn, p.logger, conf, address, p.metrics, p.probeLog)
 }
 
+// serverProperties returns the server properties sent to clients in
+// Connection.Start. Some clients read them (e.g. "version") to detect
+// broker features.
+func serverProperties() amqp091.Table {
+	return amqp091.Table{
+		"product":  "trabbits",
+		"version":  strings.TrimPrefix(Version, "v"),
+		"platform": "Go",
+		"capabilities": amqp091.Table{
+			"publisher_confirms": true,
+			"basic.nack":         true,
+		},
+	}
+}
+
 func (p *Proxy) handshake(_ context.Context) error {
 	// Connection.Start 送信
 	start := &amqp091.ConnectionStart{
-		VersionMajor: 0,
-		VersionMinor: 9,
-		Mechanisms:   "PLAIN",
-		Locales:      "en_US",
+		VersionMajor:     0,
+		VersionMinor:     9,
+		ServerProperties: serverProperties(),
+		Mechanisms:       "PLAIN",
+		Locales:          "en_US",
 	}
 	if err := p.send(0, start); err != nil {
 		return fmt.Errorf("failed to write Connection.Start: %w", err)

--- a/server_properties_test.go
+++ b/server_properties_test.go
@@ -9,6 +9,9 @@ import (
 
 func TestServerProperties(t *testing.T) {
 	t.Parallel()
+	if !testViaTrabbits {
+		t.Skip("Skipping: connected to real RabbitMQ, not trabbits")
+	}
 	conn := mustTestConn(t)
 	defer conn.Close()
 

--- a/server_properties_test.go
+++ b/server_properties_test.go
@@ -1,0 +1,37 @@
+package trabbits_test
+
+import (
+	"strings"
+	"testing"
+
+	rabbitmq "github.com/rabbitmq/amqp091-go"
+)
+
+func TestServerProperties(t *testing.T) {
+	t.Parallel()
+	conn := mustTestConn(t)
+	defer conn.Close()
+
+	props := conn.Properties
+	if got := props["product"]; got != "trabbits" {
+		t.Errorf("product = %v, want trabbits", got)
+	}
+	version, ok := props["version"].(string)
+	if !ok || version == "" {
+		t.Errorf("version = %v, want a non-empty string", props["version"])
+	}
+	// Clients (e.g. perf-test) parse the version to detect broker features,
+	// so it must be a bare version number without the "v" prefix.
+	if strings.HasPrefix(version, "v") {
+		t.Errorf("version = %q, must not have a v prefix", version)
+	}
+	caps, ok := props["capabilities"].(rabbitmq.Table)
+	if !ok {
+		t.Fatalf("capabilities = %v, want a table", props["capabilities"])
+	}
+	for _, name := range []string{"publisher_confirms", "basic.nack"} {
+		if v, _ := caps[name].(bool); !v {
+			t.Errorf("capability %s = %v, want true", name, caps[name])
+		}
+	}
+}


### PR DESCRIPTION
## What

- trabbits now sends `ServerProperties` in `Connection.Start`: `product` (trabbits), `version` (without the `v` prefix), `platform` (Go), and a `capabilities` table declaring what trabbits actually supports (`publisher_confirms`, `basic.nack`). The test is skipped when the suite runs directly against RabbitMQ (`TEST_RABBITMQ=t`).
- Limit the test workflow's `push` trigger to `main` so pull requests run CI once (previously `on: [push, pull_request]` ran it twice for same-repo branches).

## Why

Some clients read server properties to detect broker features. Recent `rabbitmq-perf-test` (`:latest`) reads the `version` property during queue configuration (`Utils.atLeast4_3`) and crashes with a NullPointerException when it is missing — this is why the "bench via trabbits" CI step currently fails on all branches, including main. Real RabbitMQ always sends these properties, so a proxy should too.

Verified locally that perf-test `:latest` fails against current main and succeeds with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)