### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -23,19 +23,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag || github.ref }}
-      - uses: Songmu/tagpr@9d0f650553240dab1fa907eca27e3fd5b586e538 # v1.18.1
+      - uses: Songmu/tagpr@9bbb945b2fb025126186661e27d55485e3fc6df6 # v1.18.3
         id: tagpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name != 'workflow_dispatch' }} # skip on workflow_dispatch
       # after tagpr adds a release tag, or workflow_dispatch, release it
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           version: '~> v2'
           args: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           docker compose -f compose.yml up -d
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
         id: go
@@ -47,7 +47,7 @@ jobs:
         run: ./scripts/coverage-summary.sh coverage.out coverage_summary.md
 
       - name: Comment PR
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: github.event_name == 'pull_request' && matrix.go == '1.26'
         with:
           script: |
@@ -61,7 +61,7 @@ jobs:
             });
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: matrix.go == '1.26'
         with:
           name: coverage-report


### PR DESCRIPTION
Consolidates the open dependabot PRs for GitHub Actions into one, keeping SHA pinning (verified with `pinact run --check`):

- `Songmu/tagpr` 1.18.1 → 1.18.3 (#124)
- `actions/setup-go` 6.3.0 → 6.4.0 (#125)
- `actions/upload-artifact` 7.0.0 → 7.0.1 (#126)
- `goreleaser/goreleaser-action` 6.4.0 → 7.2.1 (#127; the goreleaser binary version stays pinned by `version: '~> v2'`)
- `actions/github-script` 8.0.0 → 9.0.0 (#129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)