### PR TITLE
Move benchmarks to a separate workflow running on main only

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,33 @@
+name: bench
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  bench:
+    name: Bench
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+        id: go
+
+      - name: run servers for bench
+        run: |
+          make -j run-servers-for-bench &
+
+      - name: bench directly
+        run: |
+          make run-bench-rabbitmq
+
+      - name: bench via trabbits
+        run: |
+          make run-bench-trabbits

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,16 +73,3 @@ jobs:
       - name: test rabbitmq directly
         run: |
           make test TEST_RABBITMQ=t
-
-      - name: test upstreams down and bench upstream up
-        run: |
-          docker compose -f compose.yml down
-          make -j run-servers-for-bench &
-
-      - name: bench directly
-        run: |
-          make run-bench-rabbitmq
-
-      - name: bench via trabbits
-        run: |
-          make run-bench-trabbits


### PR DESCRIPTION
## What

- Move the three bench steps (start servers, bench directly, bench via trabbits) from the test workflow into a new `bench` workflow.
- The bench workflow runs on pushes to main and can be triggered manually via `workflow_dispatch`.

## Why

The perf-test benchmarks add several minutes to every pull request run, while their results only matter as a regression signal on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)