### PR TITLE
Wait for servers to start in bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,6 +24,22 @@ jobs:
         run: |
           make -j run-servers-for-bench &
 
+      - name: wait for servers
+        run: |
+          for port in 5672 6672; do
+            for i in $(seq 90); do
+              if (echo > "/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+                echo "port ${port} is ready"
+                break
+              fi
+              if [ "$i" -eq 90 ]; then
+                echo "port ${port} did not become ready" >&2
+                exit 1
+              fi
+              sleep 2
+            done
+          done
+
       - name: bench directly
         run: |
           make run-bench-rabbitmq


### PR DESCRIPTION
## What

Add a "wait for servers" step to the bench workflow that polls ports 5672 (RabbitMQ) and 6672 (trabbits) until they accept connections, before running perf-test.

## Why

The first bench run on main failed with `Connection refused`: perf-test started immediately after `make -j run-servers-for-bench &`, before RabbitMQ had booted and trabbits had been built. In the previous combined workflow, the preceding test steps implicitly gave the servers time to start.

Verified with a `workflow_dispatch` run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)