### PR TITLE
Remove comments that restate what the code does

### DIFF
--- a/amqp091/write.go
+++ b/amqp091/write.go
@@ -47,7 +47,6 @@ func (f *MethodFrame) Write(w io.Writer) (err error) {
 		return errors.New("malformed frame: missing method")
 	}
 
-	// Get buffer from pool
 	payload := bufferPool.Get().(*bytes.Buffer)
 	payload.Reset()
 	defer bufferPool.Put(payload)
@@ -84,7 +83,6 @@ func (f *HeartbeatFrame) Write(w io.Writer) (err error) {
 //
 //	short     short    long long       short        remainder...
 func (f *HeaderFrame) Write(w io.Writer) (err error) {
-	// Get buffer from pool
 	payload := bufferPool.Get().(*bytes.Buffer)
 	payload.Reset()
 	defer bufferPool.Put(payload)
@@ -228,12 +226,10 @@ func (f *BodyFrame) Write(w io.Writer) (err error) {
 }
 
 func writeFrame(w io.Writer, typ uint8, channel uint16, payload []byte) error {
-	size := uint32(len(payload)) // 型を統一
+	size := uint32(len(payload))
 
-	// 必要な容量を事前に確保
 	buf := make([]byte, 7+len(payload)+1)
 
-	// ヘッダー部分をエンコード
 	buf[0] = typ
 	buf[1] = byte(channel >> 8)
 	buf[2] = byte(channel)
@@ -242,10 +238,8 @@ func writeFrame(w io.Writer, typ uint8, channel uint16, payload []byte) error {
 	buf[5] = byte(size >> 8)
 	buf[6] = byte(size)
 
-	// ペイロードをコピー
 	copy(buf[7:], payload)
 
-	// フレームエンドをセット
 	buf[len(buf)-1] = frameEnd
 
 	// 1回の Write で送信
@@ -272,19 +266,16 @@ func writeFrameBuffer(w io.Writer, typ uint8, channel uint16, payload *bytes.Buf
 		frameEnd,
 	}
 
-	// Write header (7 bytes)
 	if _, err := w.Write(header[:7]); err != nil {
 		return err
 	}
 
-	// Write payload directly from buffer (no copy)
 	if len(payloadBytes) > 0 {
 		if _, err := w.Write(payloadBytes); err != nil {
 			return err
 		}
 	}
 
-	// Write frame end marker
 	_, err := w.Write(header[7:8])
 	return err
 }

--- a/api.go
+++ b/api.go
@@ -32,7 +32,6 @@ func listenUnixSocket(socketPath string) (net.Listener, func(), error) {
 	cancelFunc := func() {
 		os.Remove(socketPath)
 	}
-	// Create a new Unix socket listener
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		return nil, cancelFunc, fmt.Errorf("failed to listen on socket: %w", err)
@@ -120,7 +119,6 @@ func (s *Server) startAPIServer(ctx context.Context, configPath string) (func(),
 	mux.HandleFunc("GET /clients/{proxy_id}/probe", s.apiProbeLogHandler())
 	mux.HandleFunc("GET /logs", s.apiServerLogsHandler())
 	var srv http.Server
-	// start API server
 	ch := make(chan error)
 	go func() {
 		slog.Info("starting API server", "socket", s.apiSocket)
@@ -153,7 +151,6 @@ func (s *Server) startAPIServer(ctx context.Context, configPath string) (func(),
 	}, nil
 }
 
-// API handler methods for the server
 func (s *Server) apiGetConfigHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", APIContentType)
@@ -179,13 +176,11 @@ func (s *Server) apiPutConfigHandler() http.HandlerFunc {
 			return
 		}
 
-		// Reinitialize health managers with new configuration
 		if err := s.initHealthManagers(r.Context()); err != nil {
 			slog.Error("failed to reinit health managers", "error", err)
 			// Don't fail the config update, just log the error
 		}
 
-		// Update server config and disconnect outdated proxies
 		s.UpdateConfig(cfg)
 		disconnectChan := s.disconnectOutdatedProxies(cfg.Hash())
 		go func() {
@@ -209,7 +204,6 @@ func (s *Server) apiDiffConfigHandler() http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "text/plain")
 
-		// Load new config from request
 		newCfg, err := config.Load(r.Context(), configFile)
 		if err != nil {
 			slog.Error("failed to load new configuration", "error", err)
@@ -217,10 +211,8 @@ func (s *Server) apiDiffConfigHandler() http.HandlerFunc {
 			return
 		}
 
-		// Get current config
 		currentCfg := s.GetConfig()
 
-		// Generate diff using jsondiff
 		diff, err := jsondiff.Diff(
 			&jsondiff.Input{Name: "current", X: currentCfg},
 			&jsondiff.Input{Name: "new", X: newCfg},
@@ -231,7 +223,6 @@ func (s *Server) apiDiffConfigHandler() http.HandlerFunc {
 			return
 		}
 
-		// Return diff as plain text
 		w.Write([]byte(diff))
 	})
 }
@@ -254,20 +245,17 @@ func (s *Server) apiReloadConfigHandler(configPath string) http.HandlerFunc {
 func (s *Server) reloadConfigFromFile(ctx context.Context, configPath string) (*config.Config, error) {
 	slog.Info("Reloading configuration from file", "file", configPath)
 
-	// Reload config from the original config file
 	cfg, err := config.Load(ctx, configPath)
 	if err != nil {
 		slog.Error("failed to reload configuration", "error", err)
 		return nil, fmt.Errorf("failed to reload configuration: %w", err)
 	}
 
-	// Reinitialize health managers with new configuration
 	if err := s.initHealthManagers(ctx); err != nil {
 		slog.Error("failed to reinit health managers", "error", err)
 		// Don't fail the config reload, just log the error
 	}
 
-	// Update server config and disconnect outdated proxies
 	s.UpdateConfig(cfg)
 	disconnectChan := s.disconnectOutdatedProxies(cfg.Hash())
 	go func() {
@@ -293,10 +281,8 @@ func (s *Server) apiShutdownClientHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", APIContentType)
 
-		// Debug: log the request
 		slog.Debug("shutdown request received", "method", r.Method, "url", r.URL.String(), "path", r.URL.Path)
 
-		// Extract proxy ID from URL path
 		proxyID := r.PathValue("proxy_id")
 		slog.Debug("extracted proxy_id", "proxy_id", proxyID, "raw_path", r.URL.Path)
 
@@ -306,17 +292,14 @@ func (s *Server) apiShutdownClientHandler() http.HandlerFunc {
 			return
 		}
 
-		// Get optional shutdown reason from query parameter
 		shutdownReason := r.URL.Query().Get("reason")
 
-		// Attempt to shutdown the proxy
 		found := s.ShutdownProxy(proxyID, shutdownReason)
 		if !found {
 			http.Error(w, "Proxy not found", http.StatusNotFound)
 			return
 		}
 
-		// Return success response
 		response := map[string]string{
 			"status":   "shutdown_initiated",
 			"proxy_id": proxyID,
@@ -334,14 +317,12 @@ func (s *Server) apiGetClientHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", APIContentType)
 
-		// Extract proxy ID from URL path
 		proxyID := r.PathValue("proxy_id")
 		if proxyID == "" {
 			http.Error(w, "Proxy ID is required", http.StatusBadRequest)
 			return
 		}
 
-		// Get full client information
 		clientInfo, found := s.GetClientInfo(proxyID)
 		if !found {
 			http.Error(w, "Proxy not found", http.StatusNotFound)
@@ -355,26 +336,22 @@ func (s *Server) apiGetClientHandler() http.HandlerFunc {
 
 func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Extract proxy ID from URL path
 		proxyID := r.PathValue("proxy_id")
 		if proxyID == "" {
 			http.Error(w, "Proxy ID is required", http.StatusBadRequest)
 			return
 		}
 
-		// Set SSE headers
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 
-		// Try to find active proxy first
 		value, activeFound := s.activeProxies.Load(proxyID)
 		var probeChan chan probeLog
 		var isActive bool
 
 		if activeFound {
-			// Active proxy - stream logs in real-time
 			entry := value.(*proxyEntry)
 			proxy := entry.proxy
 			probeChan = proxy.GetProbeChan()
@@ -392,7 +369,6 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 			return
 		}
 
-		// Send initial connection message with proxy status
 		status := "active"
 		if !isActive {
 			status = "disconnected"
@@ -402,7 +378,6 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 			flusher.Flush()
 		}
 
-		// First, send all buffered logs
 		bufferedLogs := buffer.GetLogs()
 		for _, log := range bufferedLogs {
 			logData := struct {
@@ -427,7 +402,6 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 			}
 		}
 
-		// If proxy is not active, send proxy_ended with status and return
 		if !isActive {
 			fmt.Fprintf(w, "data: {\"type\":\"proxy_ended\",\"status\":\"disconnected\"}\n\n")
 			if flusher, ok := w.(http.Flusher); ok {
@@ -436,7 +410,6 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 			return
 		}
 
-		// For active proxies, continue streaming new logs
 		if probeChan == nil {
 			// Active proxy but no probe channel (shouldn't happen)
 			fmt.Fprintf(w, "data: {\"type\":\"proxy_ended\"}\n\n")
@@ -450,11 +423,9 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 		for {
 			select {
 			case <-ctx.Done():
-				// Client disconnected
 				return
 			case log, ok := <-probeChan:
 				if !ok {
-					// Channel closed, proxy ended
 					fmt.Fprintf(w, "data: {\"type\":\"proxy_ended\"}\n\n")
 					if flusher, ok := w.(http.Flusher); ok {
 						flusher.Flush()
@@ -462,7 +433,6 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 					return
 				}
 
-				// Convert probe log to JSON
 				logData := struct {
 					Timestamp time.Time      `json:"timestamp"`
 					Message   string         `json:"message"`
@@ -479,7 +449,6 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 					continue
 				}
 
-				// Send SSE data
 				fmt.Fprintf(w, "data: %s\n\n", jsonData)
 				if flusher, ok := w.(http.Flusher); ok {
 					flusher.Flush()
@@ -491,47 +460,37 @@ func (s *Server) apiProbeLogHandler() http.HandlerFunc {
 
 func (s *Server) apiServerLogsHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Set SSE headers
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 
-		// Send initial connection message
 		fmt.Fprintf(w, "data: {\"type\":\"connected\"}\n\n")
 		if flusher, ok := w.(http.Flusher); ok {
 			flusher.Flush()
 		}
 
-		// Create context for cleanup
 		ctx := r.Context()
 
-		// Generate unique listener ID
 		listenerID := fmt.Sprintf("api-%d", time.Now().UnixNano())
 
-		// Subscribe to log buffer
 		logChan := s.logBuffer.Subscribe(ctx, listenerID)
 
-		// Start streaming server logs
 		for {
 			select {
 			case <-ctx.Done():
-				// Client disconnected
 				return
 			case log, ok := <-logChan:
 				if !ok {
-					// Channel closed
 					return
 				}
 
-				// Send log as JSON (already in ProbeLogEntry format)
 				jsonData, err := json.Marshal(log)
 				if err != nil {
 					slog.Warn("Failed to marshal server log", "error", err)
 					continue
 				}
 
-				// Send SSE data
 				fmt.Fprintf(w, "data: %s\n\n", jsonData)
 				if flusher, ok := w.(http.Flusher); ok {
 					flusher.Flush()

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -30,7 +30,6 @@ func New(socketPath string) *Client {
 		endpoint = socketPath
 		transport = http.DefaultTransport
 	} else {
-		// Otherwise, treat it as a Unix socket path
 		endpoint = "http://localhost/"
 		transport = &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {

--- a/apiclient/config.go
+++ b/apiclient/config.go
@@ -59,7 +59,6 @@ func (c *Client) PutConfigFromFile(ctx context.Context, configPath string) error
 		return err
 	}
 
-	// Set Content-Type based on file extension
 	contentType := "application/json"
 	if strings.HasSuffix(configPath, ".jsonnet") {
 		contentType = "application/jsonnet"
@@ -110,7 +109,6 @@ func (c *Client) PutConfig(ctx context.Context, cfg *config.Config) error {
 func (c *Client) DiffConfigFromFile(ctx context.Context, configPath string) (string, error) {
 	slog.Info("getting diff from file", "file", configPath)
 
-	// Read raw file content
 	configBytes, err := os.ReadFile(configPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read config file: %w", err)
@@ -126,7 +124,6 @@ func (c *Client) DiffConfigFromFile(ctx context.Context, configPath string) (str
 		return "", err
 	}
 
-	// Set Content-Type based on file extension
 	contentType := "application/json"
 	if strings.HasSuffix(configPath, ".jsonnet") {
 		contentType = "application/jsonnet"

--- a/apiclient/probe.go
+++ b/apiclient/probe.go
@@ -91,7 +91,6 @@ func (c *Client) readProbeLogSSE(ctx context.Context, proxyID string, handler fu
 			if dataBuffer.Len() > 0 {
 				data := dataBuffer.String()
 
-				// Parse as ProbeLogEntry
 				var entry types.ProbeLogEntry
 				if err := json.Unmarshal([]byte(data), &entry); err != nil {
 					slog.Warn("Failed to parse probe log entry", "error", err, "data", data)
@@ -185,7 +184,6 @@ func (c *Client) readServerLogSSE(ctx context.Context, handler func(*types.Probe
 			if dataBuffer.Len() > 0 {
 				data := dataBuffer.String()
 
-				// Parse as ProbeLogEntry
 				var entry types.ProbeLogEntry
 				if err := json.Unmarshal([]byte(data), &entry); err != nil {
 					slog.Warn("Failed to parse server log entry", "error", err, "data", data)

--- a/apiclient/proxy.go
+++ b/apiclient/proxy.go
@@ -81,7 +81,6 @@ func (c *Client) ShutdownClient(ctx context.Context, clientID, reason string) er
 		return err
 	}
 
-	// Add reason as query parameter if provided
 	if reason != "" {
 		query := fullURL.Query()
 		query.Set("reason", reason)

--- a/cli.go
+++ b/cli.go
@@ -53,28 +53,20 @@ func Run(ctx context.Context) error {
 
 	switch k.Command() {
 	case "run":
-		// Run the server
 		return run(ctx, &cli)
 	case "manage config <command>", "manage config <command> <file>":
-		// Manage the server
 		return manageConfig(ctx, &cli)
 	case "manage clients list":
-		// Get clients information
 		return manageClients(ctx, &cli)
 	case "manage clients tui":
-		// Interactive TUI for managing clients
 		return runTUI(ctx, &cli)
 	case "manage clients shutdown <proxy-id>":
-		// Shutdown a specific proxy
 		return manageClientShutdown(ctx, &cli)
 	case "manage clients info <proxy-id>":
-		// Get detailed information for a specific proxy
 		return manageClientInfo(ctx, &cli)
 	case "manage clients probe <proxy-id>":
-		// Stream real-time probe logs for a specific proxy
 		return manageClientProbe(ctx, &cli)
 	case "test match-routing <pattern> <key>":
-		// Test routing pattern matching
 		return testMatchRouting(ctx, &cli)
 	default:
 		return fmt.Errorf("unknown command: %s", k.Command())

--- a/cmd/trabbits/main.go
+++ b/cmd/trabbits/main.go
@@ -12,7 +12,6 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Setup signal handling with logging
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, signals()...)
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/fujiwara/trabbits/amqp091"
 )
 
-// Default values for graceful shutdown
 const (
 	DefaultGracefulShutdownTimeout = 10 * time.Second
 	DefaultGracefulReloadTimeout   = 30 * time.Second
@@ -64,7 +63,6 @@ type GracefulShutdown struct {
 
 // Hash calculates SHA256 hash of the config using gob encoding
 func (c *Config) Hash() string {
-	// Use gob encoding to serialize config directly to hash writer
 	hasher := sha256.New()
 	encoder := gob.NewEncoder(hasher)
 
@@ -99,7 +97,6 @@ func Load(ctx context.Context, f string) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file: %w", err)
 		}
-		// Expand environment variables in the configuration
 		expandedData := os.ExpandEnv(string(data))
 		buf.WriteString(expandedData)
 	}
@@ -118,7 +115,6 @@ func Load(ctx context.Context, f string) (*Config, error) {
 
 // SetDefaults sets default values for config fields if not specified
 func (c *Config) SetDefaults() {
-	// Set default timeout values if not specified
 	if c.HandshakeTimeout == 0 {
 		c.HandshakeTimeout = Duration(5 * time.Second) // DefaultHandshakeTimeout
 	}
@@ -126,7 +122,6 @@ func (c *Config) SetDefaults() {
 		c.ConnectionCloseTimeout = Duration(1 * time.Second) // DefaultConnectionCloseTimeout
 	}
 
-	// Set default graceful shutdown values if not specified
 	if c.GracefulShutdown.ShutdownTimeout == 0 {
 		c.GracefulShutdown.ShutdownTimeout = Duration(DefaultGracefulShutdownTimeout)
 	}
@@ -185,12 +180,10 @@ func (u *Upstream) Validate() error {
 			if addr == "" {
 				return fmt.Errorf("address is required for cluster node")
 			}
-			// Validate address format
 			if _, _, err := net.SplitHostPort(addr); err != nil {
 				return fmt.Errorf("invalid address format for cluster node: %w", err)
 			}
 		}
-		// Validate health check credentials if health check is defined
 		if u.HealthCheck != nil {
 			if u.HealthCheck.Username == "" {
 				return fmt.Errorf("username is required for health check")
@@ -200,11 +193,9 @@ func (u *Upstream) Validate() error {
 			}
 		}
 	} else {
-		// single host
 		if u.Address == "" {
 			return fmt.Errorf("address is required")
 		}
-		// Validate address format
 		if _, _, err := net.SplitHostPort(u.Address); err != nil {
 			return fmt.Errorf("invalid address format: %w", err)
 		}

--- a/confirm.go
+++ b/confirm.go
@@ -32,7 +32,7 @@ func newConfirmState() *confirmState {
 	}
 }
 
-// recordPublish records a mapping from upstream tag to client tag.
+// RecordPublish records a mapping from upstream tag to client tag.
 // Returns the client-side delivery tag.
 func (cs *confirmState) RecordPublish(upstreamIndex int, upstreamTag uint64) uint64 {
 	cs.mu.Lock()
@@ -42,7 +42,7 @@ func (cs *confirmState) RecordPublish(upstreamIndex int, upstreamTag uint64) uin
 	return cs.clientTag
 }
 
-// lookupClientTag returns the client-side delivery tag for a given upstream confirmation
+// LookupClientTag returns the client-side delivery tag for a given upstream confirmation
 // and removes the mapping entry.
 func (cs *confirmState) LookupClientTag(upstreamIndex int, upstreamTag uint64) (uint64, bool) {
 	cs.mu.Lock()
@@ -84,7 +84,6 @@ func (p *Proxy) replyConfirmSelect(_ context.Context, f *amqp091.MethodFrame, m 
 		return err
 	}
 
-	// Put all upstream channels into confirm mode and start listeners
 	cs := newConfirmState()
 	for i, ch := range chs {
 		us := p.Upstream(i)

--- a/health/health.go
+++ b/health/health.go
@@ -142,7 +142,6 @@ func NewManager(upstream *config.Upstream, metrics MetricsReporter) *Manager {
 		return nil
 	}
 
-	// Initialize health check config with defaults
 	healthConfig := &Config{
 		Interval:           30 * time.Second,
 		Timeout:            5 * time.Second,
@@ -150,7 +149,6 @@ func NewManager(upstream *config.Upstream, metrics MetricsReporter) *Manager {
 		RecoveryInterval:   60 * time.Second,
 	}
 
-	// Override with user config if provided
 	if upstream.HealthCheck.Interval > 0 {
 		healthConfig.Interval = upstream.HealthCheck.Interval.ToDuration()
 	}
@@ -174,7 +172,6 @@ func NewManager(upstream *config.Upstream, metrics MetricsReporter) *Manager {
 		metrics:  metrics,
 	}
 
-	// Initialize node status for each cluster node
 	for _, addr := range upstream.Cluster.Nodes {
 		mgr.nodes[addr] = &NodeStatus{
 			Address: addr,
@@ -251,7 +248,6 @@ func (m *Manager) GetHealthyNodes() []string {
 		}
 	}
 
-	// If no healthy nodes, return all nodes as fallback
 	if len(healthy) == 0 {
 		m.logger.Warn("No healthy nodes found, returning all nodes")
 		for addr := range m.nodes {
@@ -281,14 +277,12 @@ func (m *Manager) checkAllNodes() {
 	}
 	wg.Wait()
 
-	// Log summary
 	healthy, unhealthy := m.getHealthSummary()
 	m.logger.Debug("Health check completed",
 		"healthy", healthy,
 		"unhealthy", unhealthy,
 		"total", len(nodes))
 
-	// Update metrics
 	if m.metrics != nil {
 		m.metrics.SetHealthyNodes(m.name, healthy)
 		m.metrics.SetUnhealthyNodes(m.name, unhealthy)
@@ -314,14 +308,12 @@ func (m *Manager) checkAllNodesInitial() {
 	}
 	wg.Wait()
 
-	// Log summary
 	healthy, unhealthy := m.getHealthSummary()
 	m.logger.Debug("Initial health check completed",
 		"healthy", healthy,
 		"unhealthy", unhealthy,
 		"total", len(nodes))
 
-	// Update metrics
 	if m.metrics != nil {
 		m.metrics.SetHealthyNodes(m.name, healthy)
 		m.metrics.SetUnhealthyNodes(m.name, unhealthy)
@@ -333,7 +325,6 @@ func (m *Manager) checkNode(node *NodeStatus, failFast bool) {
 	_, cancel := context.WithTimeout(context.Background(), m.config.Timeout)
 	defer cancel()
 
-	// Determine the failure threshold based on mode
 	threshold := m.config.UnhealthyThreshold
 	if failFast {
 		threshold = 1
@@ -351,7 +342,6 @@ func (m *Manager) checkNode(node *NodeStatus, failFast bool) {
 		}
 	}
 
-	// Try to connect to the node
 	u := &url.URL{
 		Scheme: "amqp",
 		User:   url.UserPassword(m.username, m.password),
@@ -390,7 +380,6 @@ func (m *Manager) checkNode(node *NodeStatus, failFast bool) {
 		return
 	}
 
-	// Connection successful, close it immediately
 	conn.Close()
 
 	previousStatus := node.GetStatus()

--- a/log_buffer.go
+++ b/log_buffer.go
@@ -30,13 +30,11 @@ func (b *LogBuffer) Add(entry types.ProbeLogEntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Add to buffer (keep last maxSize entries)
 	b.entries = append(b.entries, entry)
 	if len(b.entries) > b.maxSize {
 		b.entries = b.entries[len(b.entries)-b.maxSize:]
 	}
 
-	// Broadcast to all listeners (non-blocking)
 	for _, ch := range b.listeners {
 		select {
 		case ch <- entry:
@@ -52,7 +50,6 @@ func (b *LogBuffer) Subscribe(ctx context.Context, listenerID string) <-chan typ
 
 	b.mu.Lock()
 	b.listeners[listenerID] = ch
-	// Send recent entries to new subscriber
 	recentEntries := make([]types.ProbeLogEntry, len(b.entries))
 	copy(recentEntries, b.entries)
 	b.mu.Unlock()
@@ -68,7 +65,6 @@ func (b *LogBuffer) Subscribe(ctx context.Context, listenerID string) <-chan typ
 		}
 	}()
 
-	// Clean up on context cancellation
 	go func() {
 		<-ctx.Done()
 		b.Unsubscribe(listenerID)
@@ -113,38 +109,31 @@ func (h *ServerLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 
 // Handle handles the Record
 func (h *ServerLogHandler) Handle(ctx context.Context, r slog.Record) error {
-	// Extract attributes including those from WithAttrs
 	attrs := make(map[string]any)
 
-	// First add accumulated attrs from WithAttrs
 	for _, attr := range h.attrs {
 		attrs[attr.Key] = attr.Value.Any()
 	}
 
-	// Then add attrs from the record
 	r.Attrs(func(a slog.Attr) bool {
 		attrs[a.Key] = a.Value.Any()
 		return true
 	})
 
-	// Add log level to attrs
 	attrs["level"] = r.Level.String()
 
-	// Add to buffer
 	h.logBuffer.Add(types.ProbeLogEntry{
 		Timestamp: r.Time,
 		Message:   r.Message,
 		Attrs:     attrs,
 	})
 
-	// Forward to next handler
 	return h.next.Handle(ctx, r)
 }
 
 // WithAttrs returns a new Handler whose attributes consist of
 // both the receiver's attributes and the arguments
 func (h *ServerLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	// Accumulate attributes
 	newAttrs := make([]slog.Attr, len(h.attrs)+len(attrs))
 	copy(newAttrs, h.attrs)
 	copy(newAttrs[len(h.attrs):], attrs)
@@ -160,7 +149,6 @@ func (h *ServerLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 // WithGroup returns a new Handler with the given group appended to
 // the receiver's existing groups
 func (h *ServerLogHandler) WithGroup(name string) slog.Handler {
-	// Accumulate group names
 	newGroups := make([]string, len(h.groups)+1)
 	copy(newGroups, h.groups)
 	newGroups[len(h.groups)] = name

--- a/manage.go
+++ b/manage.go
@@ -137,13 +137,13 @@ func manageClientInfo(ctx context.Context, opt *CLI) error {
 	return nil
 }
 
-// runTUI starts the TUI using the new tui package
+// runTUI starts the TUI
 func runTUI(ctx context.Context, opt *CLI) error {
 	client := apiclient.New(opt.APISocket)
 	return tui.Run(ctx, client)
 }
 
-// manageProxyProbe streams real-time probe logs for a specific proxy
+// manageClientProbe streams real-time probe logs for a specific proxy
 func manageClientProbe(ctx context.Context, opt *CLI) error {
 	client := apiclient.New(opt.APISocket)
 	proxyID := opt.Manage.Clients.Probe.ProxyID
@@ -176,7 +176,6 @@ func formatProbeLogEntry(entry *types.ProbeLogEntry, format string) error {
 		}
 		fmt.Println(string(data))
 	} else {
-		// Default text format
 		attrs, _ := json.Marshal(entry.Attrs)
 		fmt.Printf("%s %s %s\n",
 			entry.Timestamp.Format("2006-01-02T15:04:05.000Z07:00"),

--- a/methods.go
+++ b/methods.go
@@ -163,7 +163,6 @@ func (p *Proxy) replyBasicConsume(ctx context.Context, f *amqp091.MethodFrame, m
 	tag := m.ConsumerTag
 	q := m.Queue
 
-	// start goroutines to consume from all upstreams
 	ctx2, cancel := context.WithCancel(ctx)
 	for us, d := range deliveries {
 		go func(us *Upstream, d *delivery) {

--- a/pattern/match.go
+++ b/pattern/match.go
@@ -13,7 +13,6 @@ import (
 //   - # matches zero or more words
 //   - % matches any substring within a single word
 func Match(routingKey, bindingPattern string) bool {
-	// Split the routing key and binding pattern by dots
 	routingTokens := strings.Split(routingKey, ".")
 	bindingTokens := strings.Split(bindingPattern, ".")
 
@@ -43,7 +42,6 @@ func matchTokens(routingTokens, bindingTokens []string, rIdx, bIdx int) bool {
 		return true
 	}
 
-	// Current tokens
 	rToken := routingTokens[rIdx]
 	bToken := bindingTokens[bIdx]
 
@@ -78,7 +76,6 @@ func matchTokens(routingTokens, bindingTokens []string, rIdx, bIdx int) bool {
 		return matchTokens(routingTokens, bindingTokens, rIdx+1, bIdx+1)
 	}
 
-	// No match
 	return false
 }
 
@@ -123,6 +120,5 @@ func matchPercentPattern(text, pattern string, textIdx, patternIdx int) bool {
 		return matchPercentPattern(text, pattern, textIdx+1, patternIdx+1)
 	}
 
-	// No match
 	return false
 }

--- a/probe.go
+++ b/probe.go
@@ -58,7 +58,6 @@ func (b *ProbeLogBuffer) Add(log probeLog) {
 
 	b.logs = append(b.logs, log)
 	if len(b.logs) > b.maxSize {
-		// Keep only the last maxSize entries
 		b.logs = b.logs[len(b.logs)-b.maxSize:]
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -46,16 +46,16 @@ type Proxy struct {
 
 	confirmStates map[uint16]*confirmState // channel ID -> confirm state for publisher confirms
 
-	configHash         string                // hash of config used for this proxy
-	upstreamDisconnect chan string           // channel to notify upstream disconnection
-	shutdownMessage    string                // message to send when shutting down
-	connectedAt        time.Time             // timestamp when the client connected
-	stats              *ProxyStats           // statistics for this proxy
-	probeChan          chan probeLog         // channel to send probe logs
-	probeLogBuffer     *ProbeLogBuffer       // buffer to store probe logs for retention
-	metrics            *metricsstore.Metrics // metrics instance for this proxy
-	tuned              tuned                 // negotiated parameters
-	heartbeatTimer     *time.Timer           // timer for heartbeat
+	configHash         string // hash of config used for this proxy
+	upstreamDisconnect chan string
+	shutdownMessage    string
+	connectedAt        time.Time
+	stats              *ProxyStats
+	probeChan          chan probeLog
+	probeLogBuffer     *ProbeLogBuffer // buffer to store probe logs for retention
+	metrics            *metricsstore.Metrics
+	tuned              tuned // negotiated parameters
+	heartbeatTimer     *time.Timer
 }
 
 type tuned struct {
@@ -82,7 +82,6 @@ func (p *Proxy) probeLog(message string, attrs ...any) {
 		attrs:     attrs, // Store as slice without conversion
 	}
 
-	// Store in buffer for retention
 	if p.probeLogBuffer != nil {
 		p.probeLogBuffer.Add(log)
 	}
@@ -94,11 +93,10 @@ func (p *Proxy) probeLog(message string, attrs ...any) {
 
 	select {
 	case p.probeChan <- log:
-		// Successfully sent
 	default:
 		// Channel is full, discard one old log and try to send the new one
 		select {
-		case <-p.probeChan: // Remove oldest log
+		case <-p.probeChan:
 		default:
 		}
 		// Try to send new log, but don't block if still full (race condition with other goroutines)
@@ -227,7 +225,6 @@ func (p *Proxy) MonitorUpstreamConnection(ctx context.Context, upstream *Upstrea
 				"upstream", upstream.String(),
 				"address", upstream.address)
 		}
-		// Notify proxy about the disconnection
 		select {
 		case p.upstreamDisconnect <- upstream.String():
 		default:
@@ -265,10 +262,8 @@ func (p *Proxy) connectToUpstreamServer(addr string, props amqp091.Table, timeou
 		Path:   p.VirtualHost,
 	}
 	p.probeLog("t->u connect", "url", safeURLString(*u))
-	// Copy all client properties and override specific ones
 	upstreamProps := rabbitmq.Table{}
 	maps.Copy(upstreamProps, props)
-	// overwrite product property to include trabbits and client address
 	upstreamProps["product"] = fmt.Sprintf("%s (%s) via trabbits/%s", props["product"], p.ClientAddr(), Version)
 
 	cfg := rabbitmq.Config{
@@ -294,10 +289,8 @@ func (p *Proxy) connectToUpstreamServers(upstreamName string, addrs []string, pr
 		nodesToTry = addrs
 	}
 
-	// Sort nodes using least connection algorithm
 	nodesToTry = p.sortNodesByLeastConnections(nodesToTry)
 
-	// Try to connect to each node
 	for _, addr := range nodesToTry {
 		conn, err := p.connectToUpstreamServer(addr, props, timeout)
 		if err == nil {
@@ -331,15 +324,13 @@ func (p *Proxy) sortNodesByLeastConnections(nodes []string) []string {
 		nodeInfos = append(nodeInfos, nodeInfo{addr: addr, connections: connections})
 	}
 
-	// Sort by connection count, then shuffle nodes with same connection count
 	sort.Slice(nodeInfos, func(i, j int) bool {
 		if nodeInfos[i].connections == nodeInfos[j].connections {
-			return rand.IntN(2) == 0 // Random order for nodes with same connection count
+			return rand.IntN(2) == 0
 		}
 		return nodeInfos[i].connections < nodeInfos[j].connections
 	})
 
-	// Create result slice with sorted addresses
 	result := make([]string, len(nodeInfos))
 	for i, info := range nodeInfos {
 		result[i] = info.addr
@@ -360,7 +351,6 @@ func (p *Proxy) ConnectToUpstreams(ctx context.Context, upstreamConfigs []config
 		us := p.newUpstream(conn, conf, addr)
 		p.upstreams = append(p.upstreams, us)
 
-		// Start monitoring the upstream connection
 		go p.MonitorUpstreamConnection(ctx, us)
 	}
 	return nil
@@ -386,7 +376,6 @@ func serverProperties() amqp091.Table {
 }
 
 func (p *Proxy) handshake(_ context.Context) error {
-	// Connection.Start 送信
 	start := &amqp091.ConnectionStart{
 		VersionMajor:     0,
 		VersionMinor:     9,
@@ -398,7 +387,6 @@ func (p *Proxy) handshake(_ context.Context) error {
 		return fmt.Errorf("failed to write Connection.Start: %w", err)
 	}
 
-	// Connection.Start-Ok 受信（認証情報含む）
 	startOk := amqp091.ConnectionStartOk{}
 	_, err := p.recvWithTimeout(0, &startOk, p.handshakeTimeout)
 	if err != nil {
@@ -425,7 +413,6 @@ func (p *Proxy) handshake(_ context.Context) error {
 		return fmt.Errorf("unsupported auth mechanism: %s", auth)
 	}
 
-	// Connection.Tune 送信
 	tune := &amqp091.ConnectionTune{
 		ChannelMax: ChannelMax,
 		FrameMax:   FrameMax,
@@ -435,7 +422,6 @@ func (p *Proxy) handshake(_ context.Context) error {
 		return fmt.Errorf("failed to write Connection.Tune: %w", err)
 	}
 
-	// Connection.Tune-Ok 受信
 	tuneOk := amqp091.ConnectionTuneOk{}
 	_, err = p.recvWithTimeout(0, &tuneOk, p.handshakeTimeout)
 	if err != nil {
@@ -451,7 +437,6 @@ func (p *Proxy) handshake(_ context.Context) error {
 	// If heartbeat is 0, heartbeat is disabled
 	p.tuned.heartbeat = tuneOk.Heartbeat
 
-	// Connection.Open 受信
 	open := amqp091.ConnectionOpen{}
 	_, err = p.recvWithTimeout(0, &open, p.handshakeTimeout)
 	if err != nil {
@@ -460,7 +445,6 @@ func (p *Proxy) handshake(_ context.Context) error {
 	p.VirtualHost = open.VirtualHost
 	p.probeLog("c->t Connection.Open", "vhost", p.VirtualHost)
 
-	// Connection.Open-Ok 送信
 	openOk := &amqp091.ConnectionOpenOk{}
 	if err := p.send(0, openOk); err != nil {
 		return fmt.Errorf("failed to write Connection.Open-Ok: %w", err)
@@ -513,9 +497,7 @@ func (p *Proxy) runHeartbeat(ctx context.Context) {
 				p.shutdown(ctx)
 				return
 			}
-			// Count heartbeat frame
 			p.stats.IncrementSentFrames()
-			// Reset timer for next heartbeat after this send
 			p.heartbeatTimer.Reset(interval)
 			p.mu.Unlock()
 		}
@@ -535,12 +517,10 @@ func (p *Proxy) getShutdownMessage() string {
 }
 
 func (p *Proxy) shutdown(ctx context.Context) error {
-	// If no connection, shutdown is immediate
 	if p.conn == nil {
 		return nil
 	}
 
-	// Connection.Close 送信
 	close := &amqp091.ConnectionClose{
 		ReplyCode: 200,
 		ReplyText: p.getShutdownMessage(),
@@ -548,7 +528,6 @@ func (p *Proxy) shutdown(ctx context.Context) error {
 	if err := p.send(0, close); err != nil {
 		return fmt.Errorf("failed to write Connection.Close: %w", err)
 	}
-	// Connection.Close-Ok 受信
 	msg := amqp091.ConnectionCloseOk{}
 	_, err := p.recv(0, &msg)
 	if err != nil {
@@ -594,7 +573,6 @@ func (p *Proxy) process(ctx context.Context) error {
 		return fmt.Errorf("failed to read frame: %w", err)
 	}
 
-	// Update frame statistics
 	p.stats.IncrementReceivedFrames()
 	p.metrics.ClientReceivedFrames.Inc()
 
@@ -627,11 +605,10 @@ func (p *Proxy) dispatchN(ctx context.Context, frame amqp091.Frame) error {
 			if err != nil {
 				return NewError(amqp091.FrameError, fmt.Sprintf("failed to read frames: %s", err))
 			}
-			f.Method = m // replace method with message
+			f.Method = m
 		}
 		methodName := amqp091.TypeName(f.Method)
 		p.metrics.ProcessedMessages.WithLabelValues(methodName).Inc()
-		// Update proxy-specific statistics
 		p.stats.IncrementMethod(methodName)
 		p.probeLog("c->t method", "channel", f.Channel(), "type", methodName)
 		switch m := f.Method.(type) {
@@ -778,7 +755,6 @@ func (p *Proxy) recvWithTimeout(channel int, m amqp091.Message, timeout time.Dur
 			p.probeLog("c->t heartbeat received")
 			// nothing to do
 		case *amqp091.HeaderFrame:
-			// start content state
 			header = f
 			remaining = int(header.Size)
 			if remaining == 0 {
@@ -787,7 +763,6 @@ func (p *Proxy) recvWithTimeout(channel int, m amqp091.Message, timeout time.Dur
 			}
 
 		case *amqp091.BodyFrame:
-			// continue until terminated
 			body = append(body, f.Body...)
 			remaining -= len(f.Body)
 			if remaining <= 0 {

--- a/server.go
+++ b/server.go
@@ -43,24 +43,22 @@ var (
 	DefaultProcessTimeout         = 5 * time.Minute // Long timeout for process loop (low-frequency clients)
 	DefaultConnectionCloseTimeout = 1 * time.Second
 
-	// Shutdown messages
 	ShutdownMsgServerShutdown = "Server shutting down"
 	ShutdownMsgConfigUpdate   = "Configuration updated, please reconnect"
 	ShutdownMsgDefault        = "Connection closed"
 
-	// ProbeLog retention
 	ProbeLogBufferSize    = 100  // Number of logs to keep per proxy
 	ProbeLogRetentionSize = 1000 // Number of proxies to retain logs for (LRU)
 )
 
 var Debug bool
 
-// Server represents a trabbits server instance
 type proxyEntry struct {
 	proxy  *Proxy
 	cancel context.CancelFunc
 }
 
+// Server represents a trabbits server instance
 type Server struct {
 	configMu          sync.RWMutex
 	config            *config.Config
@@ -69,9 +67,9 @@ type Server struct {
 	retainedProbeLogs *lru.Cache[string, *ProbeLogBuffer] // LRU cache for disconnected proxies' probe logs
 	healthManagers    sync.Map                            // upstream name -> *health.Manager
 	logger            *slog.Logger
-	apiSocket         string // API socket path
+	apiSocket         string
 	metricsStore      *metrics.Store
-	logBuffer         *LogBuffer // Buffer for server logs
+	logBuffer         *LogBuffer
 }
 
 // ServerOption configures a Server.
@@ -142,7 +140,6 @@ func (s *Server) UpdateConfig(config *config.Config) {
 func (s *Server) NewProxy(conn net.Conn) *Proxy {
 	id := generateID()
 
-	// Get config with timeout values
 	config := s.GetConfig()
 
 	// Create a probe log buffer for this proxy (will be added to LRU in RegisterProxy)
@@ -158,12 +155,12 @@ func (s *Server) NewProxy(conn net.Conn) *Proxy {
 		handshakeTimeout:       config.HandshakeTimeout.ToDuration(),
 		processTimeout:         DefaultProcessTimeout,
 		connectionCloseTimeout: config.ConnectionCloseTimeout.ToDuration(),
-		shutdownMessage:        ShutdownMsgDefault,       // default shutdown message
-		connectedAt:            time.Now(),               // timestamp when the client connected
-		stats:                  NewProxyStats(),          // initialize statistics
-		probeChan:              make(chan probeLog, 100), // buffered channel for probe logs
-		probeLogBuffer:         probeLogBuffer,           // buffer for probe log retention
-		metrics:                s.Metrics(),              // metrics instance from server
+		shutdownMessage:        ShutdownMsgDefault,
+		connectedAt:            time.Now(),
+		stats:                  NewProxyStats(),
+		probeChan:              make(chan probeLog, 100),
+		probeLogBuffer:         probeLogBuffer,
+		metrics:                s.Metrics(),
 		tuned: tuned{
 			channelMax: ChannelMax,
 			frameMax:   FrameMax,
@@ -204,7 +201,6 @@ func (s *Server) RegisterProxy(proxy *Proxy, cancel context.CancelFunc) {
 func (s *Server) UnregisterProxy(proxy *Proxy) {
 	s.activeProxies.Delete(proxy.id)
 
-	// Mark buffer as inactive and add to LRU for retention after disconnection
 	if proxy.probeLogBuffer != nil {
 		proxy.probeLogBuffer.MarkInactive()
 		s.retainedProbeLogs.Add(proxy.id, proxy.probeLogBuffer)
@@ -214,12 +210,10 @@ func (s *Server) UnregisterProxy(proxy *Proxy) {
 // GetProbeLogBuffer returns the probe log buffer for a given proxy ID
 // First checks active proxies, then falls back to LRU cache for disconnected proxies
 func (s *Server) GetProbeLogBuffer(proxyID string) (*ProbeLogBuffer, bool) {
-	// First, try to get from active proxy (which always has its buffer)
 	if value, ok := s.activeProxies.Load(proxyID); ok {
 		entry := value.(*proxyEntry)
 		return entry.proxy.probeLogBuffer, true
 	}
-	// Fall back to LRU cache for disconnected proxies
 	return s.retainedProbeLogs.Get(proxyID)
 }
 
@@ -237,7 +231,6 @@ func (srv *Server) disconnectProxies(reason string, shutdownMessage string, maxT
 		srv.activeProxies.Range(func(key, value any) bool {
 			entry := value.(*proxyEntry)
 			if filter(entry.proxy) {
-				// Set the shutdown message for this proxy
 				entry.proxy.setShutdownMessage(shutdownMessage)
 				targetProxies = append(targetProxies, entry.proxy)
 				targetCancels = append(targetCancels, entry.cancel)
@@ -247,37 +240,30 @@ func (srv *Server) disconnectProxies(reason string, shutdownMessage string, maxT
 
 		disconnectedCount := len(targetProxies)
 		if disconnectedCount == 0 {
-			// No target proxies found, return immediately
 			resultChan <- 0
 			return
 		}
 		slog.Info(reason, "count", disconnectedCount)
 
-		// Rate limiter: use configured values
 		// In test environment, use higher rate for faster tests
 		rateLimitValue := rate.Limit(rateLimit)
-		if disconnectedCount <= 10 { // Small number for tests
-			rateLimitValue = rate.Limit(1000) // 1000/sec for small tests
+		if disconnectedCount <= 10 {
+			rateLimitValue = rate.Limit(1000)
 			burstSize = 100
 		}
 		limiter := rate.NewLimiter(rateLimitValue, burstSize)
 
-		// Number of worker goroutines for parallel processing
 		const numWorkers = 10
 
-		// Channel to distribute work to workers
 		cancelChan := make(chan context.CancelFunc, len(targetCancels))
 
-		// Send all cancel functions to the channel
 		for _, cancel := range targetCancels {
 			cancelChan <- cancel
 		}
 		close(cancelChan)
 
-		// Use sync.WaitGroup to wait for all worker goroutines to complete
 		var wg sync.WaitGroup
 
-		// Start worker goroutines
 		for i := range numWorkers {
 			wg.Add(1)
 			go func(workerID int) {
@@ -285,7 +271,6 @@ func (srv *Server) disconnectProxies(reason string, shutdownMessage string, maxT
 				defer wg.Done()
 
 				for cancel := range cancelChan {
-					// Wait for rate limiter
 					if err := limiter.Wait(context.Background()); err != nil {
 						slog.Warn("Rate limiter context cancelled", "error", err)
 						continue
@@ -298,7 +283,6 @@ func (srv *Server) disconnectProxies(reason string, shutdownMessage string, maxT
 			}(i)
 		}
 
-		// Wait for all workers to complete with appropriate timeout
 		// Calculate timeout based on proxy count and rate limit
 		actualRate := float64(rateLimitValue)
 		expectedDuration := float64(disconnectedCount)/actualRate + 1 // Plus 1 second buffer
@@ -316,16 +300,13 @@ func (srv *Server) disconnectProxies(reason string, shutdownMessage string, maxT
 
 		select {
 		case <-done:
-			// All disconnections completed successfully
 			slog.Info("All proxy disconnections completed", "count", disconnectedCount)
 		case <-time.After(timeoutDuration):
-			// Timeout - some disconnections might be hanging
 			slog.Warn("Timeout waiting for proxy disconnections to complete",
 				"timeout", timeoutDuration,
 				"expected_duration", fmt.Sprintf("%.1fs", float64(disconnectedCount)/actualRate))
 		}
 
-		// Send the count of disconnected proxies
 		resultChan <- disconnectedCount
 	}()
 
@@ -393,7 +374,6 @@ func run(ctx context.Context, opt *CLI) error {
 		}
 	}()
 
-	// Create server instance
 	server := NewServer(cfg, opt.APISocket, WithMetricsStore(metricsStore))
 
 	// Setup server log handler to capture logs for API streaming,
@@ -403,7 +383,6 @@ func run(ctx context.Context, opt *CLI) error {
 	serverLogHandler := NewServerLogHandler(server.logBuffer, metricHandler)
 	slog.SetDefault(slog.New(serverLogHandler))
 
-	// Write PID file if specified
 	if opt.Run.PidFile != "" {
 		if err := writePidFile(opt.Run.PidFile); err != nil {
 			return fmt.Errorf("failed to write PID file: %w", err)
@@ -411,7 +390,6 @@ func run(ctx context.Context, opt *CLI) error {
 		defer removePidFile(opt.Run.PidFile)
 	}
 
-	// Initialize health check managers for cluster upstreams
 	if err := server.initHealthManagers(ctx); err != nil {
 		return fmt.Errorf("failed to init health managers: %w", err)
 	}
@@ -422,7 +400,6 @@ func run(ctx context.Context, opt *CLI) error {
 	}
 	defer cancelAPI()
 
-	// Setup SIGHUP handler for config reload
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGHUP)
 	go func() {
@@ -481,7 +458,6 @@ func (srv *Server) boot(ctx context.Context, listener net.Listener) error {
 		}
 		slog.Info("Listener closed, no new connections will be accepted")
 
-		// Then gracefully disconnect all active connections
 		disconnectChan := srv.disconnectAllProxies()
 		cfg := srv.GetConfig()
 		select {
@@ -520,7 +496,6 @@ func (srv *Server) boot(ctx context.Context, listener net.Listener) error {
 
 // initHealthManagers initializes health check managers for cluster upstreams
 func (srv *Server) initHealthManagers(ctx context.Context) error {
-	// Stop existing health managers
 	srv.healthManagers.Range(func(key, value any) bool {
 		if mgr, ok := value.(*health.Manager); ok {
 			mgr.Stop()
@@ -529,7 +504,6 @@ func (srv *Server) initHealthManagers(ctx context.Context) error {
 		return true
 	})
 
-	// Create new health managers for cluster upstreams
 	cfg := srv.GetConfig()
 	for _, upstream := range cfg.Upstreams {
 		if upstream.Cluster != nil && upstream.HealthCheck != nil {
@@ -574,8 +548,7 @@ func (srv *Server) handleConnection(ctx context.Context, conn net.Conn) {
 	}()
 
 	slog.Info("new connection", "client_addr", conn.RemoteAddr().String(), "handshake_timeout", srv.config.HandshakeTimeout)
-	conn.SetReadDeadline(time.Now().Add(srv.config.HandshakeTimeout.ToDuration())) // Set read deadline for handshake
-	// AMQP プロトコルヘッダー受信
+	conn.SetReadDeadline(time.Now().Add(srv.config.HandshakeTimeout.ToDuration()))
 	header := make([]byte, 8)
 	if _, err := io.ReadFull(conn, header); err != nil {
 		slog.Warn("Failed to read AMQP header:", "error", err)
@@ -602,7 +575,6 @@ func (srv *Server) handleConnection(ctx context.Context, conn net.Conn) {
 	}
 	p.logger.Debug("handshake completed")
 
-	// subCtx is used for client connection depends on parent context
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -618,20 +590,17 @@ func (srv *Server) handleConnection(ctx context.Context, conn net.Conn) {
 	p.initHeartbeatTimer()
 	go p.runHeartbeat(subCtx)
 
-	// wait for client frames
 	for {
 		select {
-		case <-ctx.Done(): // parent (server) context is done
-			p.shutdown(subCtx) // graceful shutdown
-			return             // subCtx will be canceled by defer ^
+		case <-ctx.Done():
+			p.shutdown(subCtx)
+			return // subCtx will be canceled by defer ^
 		case <-subCtx.Done():
-			p.shutdown(subCtx) // graceful shutdown when context is cancelled
+			p.shutdown(subCtx)
 			return
 		case upstreamName := <-p.upstreamDisconnect:
-			// An upstream connection was lost
 			p.logger.Error("Upstream connection lost, closing client connection",
 				"upstream", upstreamName)
-			// Send Connection.Close to client with connection-forced error
 			p.sendConnectionError(NewError(amqp091.ConnectionForced,
 				fmt.Sprintf("Upstream connection lost: %s", upstreamName)))
 			return
@@ -672,13 +641,11 @@ func (s *Server) GetClientsInfo() []types.ClientInfo {
 	clients := make([]types.ClientInfo, 0) // Initialize as empty slice instead of nil
 	activeProxyIDs := make(map[string]bool)
 
-	// First, add all active proxies
 	s.activeProxies.Range(func(key, value any) bool {
 		entry := value.(*proxyEntry)
 		proxy := entry.proxy
 		activeProxyIDs[proxy.id] = true
 
-		// Determine status based on shutdown message
 		status := types.ClientStatusActive
 		shutdownReason := ""
 		if proxy.shutdownMessage != ShutdownMsgDefault {
@@ -698,7 +665,6 @@ func (s *Server) GetClientsInfo() []types.ClientInfo {
 			ShutdownReason:   shutdownReason,
 		}
 
-		// Add statistics summary if available
 		if proxy.stats != nil {
 			snapshot := proxy.stats.Snapshot()
 			clientInfo.Stats = &types.StatsSummary{
@@ -713,9 +679,7 @@ func (s *Server) GetClientsInfo() []types.ClientInfo {
 		return true
 	})
 
-	// Then, add disconnected proxies from LRU cache
 	for _, proxyID := range s.retainedProbeLogs.Keys() {
-		// Skip if already in active proxies
 		if activeProxyIDs[proxyID] {
 			continue
 		}
@@ -725,7 +689,6 @@ func (s *Server) GetClientsInfo() []types.ClientInfo {
 			continue
 		}
 
-		// Get proxy info from buffer
 		clientAddr, user, virtualHost, clientBanner, connectedAt := buffer.GetProxyInfo()
 
 		clientInfo := types.ClientInfo{
@@ -742,7 +705,6 @@ func (s *Server) GetClientsInfo() []types.ClientInfo {
 		clients = append(clients, clientInfo)
 	}
 
-	// Sort clients by connection time (oldest first)
 	sort.Slice(clients, func(i, j int) bool {
 		return clients[i].ConnectedAt.Before(clients[j].ConnectedAt)
 	})
@@ -752,13 +714,11 @@ func (s *Server) GetClientsInfo() []types.ClientInfo {
 
 // GetClientInfo returns full client information including ClientProperties and complete stats
 func (s *Server) GetClientInfo(proxyID string) (*types.FullClientInfo, bool) {
-	// First, try to find in active proxies
 	value, ok := s.activeProxies.Load(proxyID)
 	if ok {
 		entry := value.(*proxyEntry)
 		proxy := entry.proxy
 
-		// Determine status based on shutdown message
 		status := types.ClientStatusActive
 		shutdownReason := ""
 		if proxy.shutdownMessage != ShutdownMsgDefault {
@@ -778,7 +738,6 @@ func (s *Server) GetClientInfo(proxyID string) (*types.FullClientInfo, bool) {
 			ShutdownReason:   shutdownReason,
 		}
 
-		// Add complete statistics if available
 		if proxy.stats != nil {
 			snapshot := proxy.stats.Snapshot()
 			clientInfo.Stats = &types.FullStatsSummary{
@@ -795,13 +754,11 @@ func (s *Server) GetClientInfo(proxyID string) (*types.FullClientInfo, bool) {
 		return clientInfo, true
 	}
 
-	// If not active, try to find in disconnected proxies
 	buffer, ok := s.retainedProbeLogs.Get(proxyID)
 	if !ok || buffer.IsActive() {
 		return nil, false
 	}
 
-	// Get proxy info from buffer
 	clientAddr, user, virtualHost, clientBanner, connectedAt := buffer.GetProxyInfo()
 
 	clientInfo := &types.FullClientInfo{
@@ -840,7 +797,6 @@ func (s *Server) ShutdownProxy(proxyID string, shutdownReason string) bool {
 		"vhost", proxy.VirtualHost,
 		"reason", shutdownReason)
 
-	// Set custom shutdown message
 	proxy.shutdownMessage = shutdownReason
 	// Trigger graceful shutdown
 	entry.cancel()

--- a/server_linux.go
+++ b/server_linux.go
@@ -15,7 +15,6 @@ func newListener(ctx context.Context, addr string) (net.Listener, error) {
 		Control: func(network, address string, c syscall.RawConn) error {
 			var opErr error
 			err := c.Control(func(fd uintptr) {
-				// SO_REUSEPORT
 				opErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 			})
 			if err != nil {

--- a/stats.go
+++ b/stats.go
@@ -25,20 +25,20 @@ func NewProxyStats() *ProxyStats {
 
 // IncrementMethod increments the counter for a specific AMQP method
 func (s *ProxyStats) IncrementMethod(method string) {
-	// Update local counter only - Prometheus metrics are updated directly in proxy.go
+	// Update local counter only - metrics are updated directly in proxy.go
 	v, _ := s.methodCounts.LoadOrStore(method, new(int64))
 	atomic.AddInt64(v.(*int64), 1)
 }
 
 // IncrementReceivedFrames increments the received frame counter
 func (s *ProxyStats) IncrementReceivedFrames() {
-	// Update local counter only - Prometheus metrics are updated directly in proxy.go
+	// Update local counter only - metrics are updated directly in proxy.go
 	atomic.AddInt64(&s.receivedFrames, 1)
 }
 
 // IncrementSentFrames increments the sent frame counter
 func (s *ProxyStats) IncrementSentFrames() {
-	// Update local counter only - Prometheus metrics are updated directly in proxy.go
+	// Update local counter only - metrics are updated directly in proxy.go
 	atomic.AddInt64(&s.sentFrames, 1)
 }
 

--- a/tui/format.go
+++ b/tui/format.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fujiwara/trabbits/types"
 )
 
-// Styles for formatting
 var (
 	activeStatusStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("46"))

--- a/tui/model.go
+++ b/tui/model.go
@@ -81,7 +81,7 @@ type probeState struct {
 	clientID       string
 	logs           []probeLogEntry
 	scroll         int
-	selectedIdx    int // Currently selected log index
+	selectedIdx    int
 	cancelFunc     context.CancelFunc
 	ctx            context.Context
 	logChan        <-chan ProbeLogEntry
@@ -173,7 +173,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			total = clamp(total, 0, total) // no-op, placeholder for clarity
 			m.serverLogsSelectedIdx = clamp(m.serverLogsSelectedIdx, 0, clamp(total-1, -1, total-1))
 			m.serverLogsScroll = clampScrollToContain(m.serverLogsScroll, m.serverLogsSelectedIdx, visible, total)
-			// Ensure bounds when there are no logs
 			if total == 0 {
 				m.serverLogsSelectedIdx = 0
 				m.serverLogsScroll = 0
@@ -192,10 +191,8 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKeyPress(msg)
 
 	case tickMsg:
-		// Always fetch clients list on every tick (every 2 seconds)
 		cmds := []tea.Cmd{m.fetchClients(), tick()}
 
-		// If in detail view, also fetch updated client detail
 		if m.viewMode == ViewDetail && m.clientDetail != nil {
 			cmds = append(cmds, m.fetchClientDetail(m.clientDetail.ID))
 		}
@@ -214,7 +211,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		sort.SliceStable(m.clients, func(i, j int) bool {
 			ci, cj := m.clients[i], m.clients[j]
 
-			// Active clients come before closed clients
 			if ci.Status == "active" && cj.Status != "active" {
 				return true
 			}
@@ -222,22 +218,18 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return false
 			}
 
-			// Among active clients, older connections first
 			if ci.Status == "active" && cj.Status == "active" {
 				return ci.ConnectedAt.Before(cj.ConnectedAt)
 			}
 
-			// Among closed clients, newer disconnections first (most recently closed)
 			if ci.Status == "disconnected" && cj.Status == "disconnected" {
 				return ci.DisconnectedAt.After(cj.DisconnectedAt)
 			}
 
-			// Default: maintain order
 			return false
 		})
 
 		m.lastUpdate = time.Now()
-		// Try to restore selection to the same client ID
 		if prevSelectedID != "" {
 			restored := false
 			for i, c := range m.clients {
@@ -253,7 +245,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else if len(m.clients) > 0 && m.selectedIdx >= len(m.clients) {
 			m.selectedIdx = len(m.clients) - 1
 		}
-		// Ensure selection remains visible and scroll stays in bounds
 		m.adjustScrollForSelection()
 		return m, nil
 
@@ -274,7 +265,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case successMsg:
 		m.successMsg = string(msg)
 		m.successTime = time.Now()
-		// If we were in save confirm view, return to previous view
 		if m.viewMode == ViewSaveConfirm && m.saveState != nil {
 			m.viewMode = m.saveState.previousView
 			m.saveState = nil
@@ -289,10 +279,8 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.probeState.logs) > probeLogKeep {
 				m.probeState.logs = m.probeState.logs[len(m.probeState.logs)-probeLogKeep:]
 			}
-			// Auto-scroll to bottom only if auto-scroll is enabled
 			if m.probeState.autoScroll {
-				m.probeState.selectedIdx = len(m.probeState.logs) - 1 // Select the latest log
-				// Adjust scroll to show the last item
+				m.probeState.selectedIdx = len(m.probeState.logs) - 1
 				visibleRows := m.getProbeVisibleRows()
 				total := len(m.probeState.logs)
 				m.probeState.scroll = maxScroll(total, visibleRows)
@@ -301,7 +289,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !m.probeState.autoScroll {
 				visible := m.getProbeVisibleRows()
 				total := len(m.probeState.logs)
-				// Keep selectedIdx inside bounds
 				m.probeState.selectedIdx = clamp(m.probeState.selectedIdx, 0, clamp(total-1, -1, total-1))
 				m.probeState.scroll = clamp(m.probeState.scroll, 0, maxScroll(total, visible))
 			}
@@ -329,11 +316,9 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			// Probe stream ended, attempt to reconnect
 			clientID := m.probeState.clientID
 			reconnectCount := m.probeState.reconnectCount
 
-			// Limit reconnection attempts
 			if reconnectCount >= 5 {
 				m.err = fmt.Errorf("probe stream ended after %d reconnection attempts", reconnectCount)
 				m.errorTime = time.Now()
@@ -345,11 +330,9 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			logs := m.probeState.logs
 			m.stopProbeStream()
 
-			// Add a message about reconnecting
 			m.err = fmt.Errorf("probe stream disconnected, reconnecting... (attempt %d/5)", reconnectCount+1)
 			m.errorTime = time.Now()
 
-			// Restart the probe stream with incremented reconnect count after a short delay
 			return m, tea.Tick(time.Second, func(time.Time) tea.Msg {
 				return reconnectProbeMsg{clientID: clientID, logs: logs, reconnectCount: reconnectCount + 1}
 			})
@@ -357,7 +340,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case probeStreamStartedMsg:
-		// Initialize probe state and start listening
 		m.probeState = &probeState{
 			clientID:    msg.clientID,
 			logs:        []probeLogEntry{},
@@ -366,19 +348,17 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cancelFunc:  msg.cancelFunc,
 			ctx:         msg.ctx,
 			logChan:     msg.logChan,
-			autoScroll:  true, // start with auto-scroll enabled
+			autoScroll:  true,
 		}
 		return m, m.listenForProbeLog()
 
 	case reconnectProbeMsg:
-		// Handle reconnection with preserved logs only when still in probe view
 		if m.viewMode != ViewProbe {
 			return m, nil
 		}
 		return m, m.startProbeStreamWithState(msg.clientID, msg.logs, msg.reconnectCount, false)
 
 	case probeStreamStartedMsgWithState:
-		// Initialize probe state with preserved logs and start listening
 		if m.viewMode != ViewProbe {
 			// View changed while starting; cancel to avoid leak
 			if msg.cancelFunc != nil {
@@ -394,7 +374,7 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			clientID:       msg.clientID,
 			logs:           logs,
 			scroll:         0,
-			selectedIdx:    len(logs) - 1, // Select the last log if there are existing logs
+			selectedIdx:    len(logs) - 1,
 			cancelFunc:     msg.cancelFunc,
 			ctx:            msg.ctx,
 			logChan:        msg.logChan,
@@ -402,7 +382,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			reconnectCount: msg.reconnectCount,
 			disconnected:   msg.disconnected,
 		}
-		// Ensure selectedIdx is not negative
 		if m.probeState.selectedIdx < 0 {
 			m.probeState.selectedIdx = 0
 		}
@@ -415,7 +394,6 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.listenForProbeLog()
 
 	case logMsg:
-		// Add log entry to buffer with cached AttrJSON
 		entry := LogEntry(msg)
 		if len(entry.Attrs) > 0 {
 			// Filter out level before caching
@@ -503,7 +481,6 @@ func (m *TUIModel) startProbeStreamWithState(clientID string, preservedLogs []pr
 			return errorMsg(err)
 		}
 
-		// Set up a modified probeStreamStartedMsg to preserve logs and reconnect count
 		return probeStreamStartedMsgWithState{
 			clientID:       clientID,
 			ctx:            ctx,
@@ -575,21 +552,18 @@ func (m *TUIModel) saveProbeLogsToFile() tea.Cmd {
 		filePath := m.saveState.filePath
 		logs := m.probeState.logs
 
-		// Ensure parent directory exists if specified
 		if dir := filepath.Dir(filePath); dir != "." && dir != "" {
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return errorMsg(fmt.Errorf("failed to create directory %s: %w", dir, err))
 			}
 		}
 
-		// Create file
 		file, err := os.Create(filePath)
 		if err != nil {
 			return errorMsg(fmt.Errorf("failed to create file: %w", err))
 		}
 		defer file.Close()
 
-		// Write logs as JSON lines
 		encoder := json.NewEncoder(file)
 		for _, log := range logs {
 			if err := encoder.Encode(log); err != nil {

--- a/tui/scroll.go
+++ b/tui/scroll.go
@@ -25,15 +25,11 @@ func clampScrollToContain(scroll, selected, visible, total int) int {
 	if visible <= 0 {
 		return 0
 	}
-	// Ensure scroll is within bounds first
 	ms := maxScroll(total, visible)
 	scroll = min(
-		// Scroll up if selected is above
 		selected, clamp(scroll, 0, ms))
-	// Scroll down if selected is below visible window
 	if selected >= scroll+visible {
 		scroll = selected - visible + 1
 	}
-	// Clamp again
 	return clamp(scroll, 0, ms)
 }

--- a/tui/slog_handler.go
+++ b/tui/slog_handler.go
@@ -27,14 +27,12 @@ func (h *TUIHandler) Enabled(ctx context.Context, level slog.Level) bool {
 
 // Handle handles the Record
 func (h *TUIHandler) Handle(ctx context.Context, r slog.Record) error {
-	// Extract attributes
 	attrs := make(map[string]any)
 	r.Attrs(func(a slog.Attr) bool {
 		attrs[a.Key] = a.Value.Any()
 		return true
 	})
 
-	// Send to TUI channel (non-blocking)
 	select {
 	case h.logChan <- LogEntry{
 		Time:    r.Time,
@@ -46,7 +44,6 @@ func (h *TUIHandler) Handle(ctx context.Context, r slog.Record) error {
 		// Channel full, skip this log to avoid blocking
 	}
 
-	// Forward to next handler
 	return h.next.Handle(ctx, r)
 }
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -20,7 +20,6 @@ func Run(ctx context.Context, apiClient apiclient.APIClient) error {
 
 	model := NewModel(ctx, apiClient)
 
-	// Start streaming server logs from API
 	go func() {
 		logChan, err := apiClient.StreamServerLogs(ctx)
 		if err != nil {
@@ -28,9 +27,7 @@ func Run(ctx context.Context, apiClient apiclient.APIClient) error {
 			return
 		}
 
-		// Forward server logs to TUI log channel
 		for log := range logChan {
-			// Extract level from attrs if present
 			level := "INFO"
 			if log.Attrs != nil {
 				if l, ok := log.Attrs["level"].(string); ok {
@@ -38,7 +35,6 @@ func Run(ctx context.Context, apiClient apiclient.APIClient) error {
 				}
 			}
 
-			// Convert ProbeLogEntry to LogEntry
 			entry := LogEntry{
 				Time:    log.Timestamp,
 				Level:   level,
@@ -80,7 +76,6 @@ func (m *TUIModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// View-specific key handling
 	switch m.viewMode {
 	case ViewList:
 		return m.handleListKeys(msg)
@@ -107,7 +102,6 @@ func (m *TUIModel) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selectedIdx = 0
 		m.listScroll = 0
 	case "K":
-		// Shutdown client
 		if len(m.clients) > 0 && m.selectedIdx < len(m.clients) {
 			client := m.clients[m.selectedIdx]
 			if client.ID == "" {
@@ -167,21 +161,17 @@ func (m *TUIModel) handleListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		return m, m.fetchClients()
 	case "p":
-		// Start probe stream for selected client
 		if len(m.clients) > 0 {
 			client := m.clients[m.selectedIdx]
 			m.viewMode = ViewProbe
-			// Check if this is a disconnected proxy
 			disconnected := client.Status == "disconnected"
 			return m, m.startProbeStreamWithDisconnected(client.ID, disconnected)
 		}
 	case "l":
-		// Switch to server logs view
 		m.viewMode = ViewServerLogs
 		// Initialize scroll to bottom
 		if len(m.logEntries) > 0 {
 			m.serverLogsSelectedIdx = len(m.logEntries) - 1
-			// Scroll so that the last entry is visible
 			visible := max(m.getServerLogsVisibleRows(), 1)
 			maxScroll := max(len(m.logEntries)-visible, 0)
 			m.serverLogsScroll = maxScroll
@@ -201,7 +191,6 @@ func (m *TUIModel) handleDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.clientDetail = nil
 		m.detailScroll = 0
 	case "K":
-		// Shutdown client from detail view
 		if m.clientDetail != nil {
 			m.confirmState = &confirmState{
 				clientID: m.clientDetail.ID,
@@ -222,10 +211,8 @@ func (m *TUIModel) handleDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Set to large number, will be limited in render
 		m.detailScroll = 1000
 	case "p":
-		// Start probe stream for current client
 		if m.clientDetail != nil {
 			m.viewMode = ViewProbe
-			// Check if this is a disconnected proxy
 			disconnected := m.clientDetail.Status == "disconnected"
 			return m, m.startProbeStreamWithDisconnected(m.clientDetail.ID, disconnected)
 		}
@@ -254,7 +241,6 @@ func (m *TUIModel) handleConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+c", "q", "esc":
-		// Stop probe stream and return to list view
 		m.stopProbeStream()
 		m.viewMode = ViewList
 	case "g":
@@ -264,17 +250,14 @@ func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.probeState.autoScroll = false
 		}
 	case " ":
-		// Toggle auto-scroll with space key
 		if m.probeState != nil {
 			m.probeState.autoScroll = !m.probeState.autoScroll
-			// If enabling auto-scroll, jump to bottom
 			if m.probeState.autoScroll && len(m.probeState.logs) > 0 {
 				m.probeState.selectedIdx = len(m.probeState.logs) - 1
 				visibleRows := m.getProbeVisibleRows()
 				maxScroll := max(len(m.probeState.logs)-visibleRows, 0)
 				m.probeState.scroll = maxScroll
 			}
-			// Show a short toast indicating the state
 			if m.probeState.autoScroll {
 				m.successMsg = "Auto-scroll: ON"
 			} else {
@@ -283,7 +266,6 @@ func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.successTime = time.Now()
 		}
 	case "s":
-		// Save probe logs to file
 		if m.probeState != nil {
 			clientID := m.probeState.clientID
 			timestamp := time.Now().Format("20060102-150405")
@@ -303,7 +285,6 @@ func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if m.probeState.selectedIdx > 0 {
 				m.probeState.selectedIdx--
 			}
-			// Clamp scroll to contain the selection
 			m.probeState.scroll = clampScrollToContain(m.probeState.scroll, m.probeState.selectedIdx, m.getProbeVisibleRows(), total)
 			m.probeState.autoScroll = false // Disable auto-scroll on manual navigation
 		}
@@ -314,7 +295,7 @@ func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.probeState.selectedIdx++
 			}
 			m.probeState.scroll = clampScrollToContain(m.probeState.scroll, m.probeState.selectedIdx, m.getProbeVisibleRows(), total)
-			m.updateAutoScroll() // Check if we should enable/disable auto-scroll
+			m.updateAutoScroll()
 		}
 	case "home":
 		if m.probeState != nil {
@@ -325,7 +306,6 @@ func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "end":
 		if m.probeState != nil && len(m.probeState.logs) > 0 {
 			m.probeState.selectedIdx = len(m.probeState.logs) - 1
-			// Adjust scroll to show the last item
 			visibleRows := m.getProbeVisibleRows()
 			maxScroll := max(len(m.probeState.logs)-visibleRows, 0)
 			m.probeState.scroll = maxScroll
@@ -358,7 +338,7 @@ func (m *TUIModel) handleProbeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.probeState.selectedIdx = logCount - 1
 			}
 			m.probeState.scroll = clampScrollToContain(m.probeState.scroll, m.probeState.selectedIdx, m.getProbeVisibleRows(), logCount)
-			m.updateAutoScroll() // Check if we should enable/disable auto-scroll
+			m.updateAutoScroll()
 		}
 	}
 	return m, nil
@@ -374,7 +354,6 @@ func (m *TUIModel) updateAutoScroll() {
 	visibleRows := m.getProbeVisibleRows()
 	maxScroll := max(logCount-visibleRows, 0)
 
-	// Enable auto-scroll only when we're at or near the bottom
 	m.probeState.autoScroll = m.probeState.scroll >= maxScroll
 }
 
@@ -395,7 +374,6 @@ func (m *TUIModel) handleServerLogsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.viewMode = ViewList
 		m.serverLogsScroll = 0
 	case "g":
-		// Jump to top
 		m.serverLogsSelectedIdx = 0
 		m.serverLogsScroll = 0
 	case "up", "k":
@@ -433,13 +411,11 @@ func (m *TUIModel) handleServerLogsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.adjustServerLogsScroll()
 		}
 	case "G":
-		// Jump to bottom
 		if len(m.logEntries) > 0 {
 			m.serverLogsSelectedIdx = len(m.logEntries) - 1
 			m.adjustServerLogsScroll()
 		}
 	case "R":
-		// Reset dropped logs counter
 		m.droppedLogs = 0
 		m.successMsg = "Dropped logs reset"
 		m.successTime = time.Now()
@@ -481,23 +457,18 @@ func (m *TUIModel) handleSaveConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.saveState.editing {
-		// Editing mode
 		switch msg.Type {
 		case tea.KeyEsc:
-			// Stop editing
 			m.saveState.editing = false
 		case tea.KeyEnter:
-			// Confirm with current path
 			m.saveState.editing = false
 		case tea.KeyBackspace:
-			// Delete character before cursor
 			if m.saveState.cursorPos > 0 {
 				path := m.saveState.filePath
 				m.saveState.filePath = path[:m.saveState.cursorPos-1] + path[m.saveState.cursorPos:]
 				m.saveState.cursorPos--
 			}
 		case tea.KeyDelete:
-			// Delete character at cursor
 			if m.saveState.cursorPos < len(m.saveState.filePath) {
 				path := m.saveState.filePath
 				m.saveState.filePath = path[:m.saveState.cursorPos] + path[m.saveState.cursorPos+1:]
@@ -515,7 +486,6 @@ func (m *TUIModel) handleSaveConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnd:
 			m.saveState.cursorPos = len(m.saveState.filePath)
 		case tea.KeyRunes:
-			// Insert runes at cursor (basic rune-aware insertion)
 			path := m.saveState.filePath
 			for _, r := range msg.Runes {
 				s := string(r)
@@ -525,14 +495,11 @@ func (m *TUIModel) handleSaveConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.saveState.filePath = path
 		}
 	} else {
-		// Not editing mode
 		switch msg.String() {
 		case "ctrl+c", "esc", "n", "q":
-			// Cancel save
 			m.viewMode = m.saveState.previousView
 			m.saveState = nil
 		case "e":
-			// Start editing
 			m.saveState.editing = true
 			m.saveState.overwriteConfirm = false
 		case "enter":
@@ -541,13 +508,11 @@ func (m *TUIModel) handleSaveConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				path := m.saveState.filePath
 				if !m.saveState.overwriteConfirm {
 					if _, err := os.Stat(path); err == nil {
-						// File exists, require explicit confirmation
 						m.saveState.overwriteConfirm = true
 						return m, nil
 					}
 				}
 			}
-			// Proceed to save
 			return m, m.saveProbeLogsToFile()
 		}
 	}

--- a/tui/view.go
+++ b/tui/view.go
@@ -12,7 +12,6 @@ import (
 	runewidth "github.com/mattn/go-runewidth"
 )
 
-// Styles for rendering
 var (
 	headerStyle = lipgloss.NewStyle().
 			Bold(true).
@@ -46,7 +45,6 @@ var (
 	cursorStyle     = lipgloss.NewStyle().Background(lipgloss.Color("255")).Foreground(lipgloss.Color("0")).Render(" ")
 	logPaneBoxStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240")).Padding(0, 1)
 
-	// Log level styles
 	levelErrorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
 	levelWarnStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("226"))
 	levelInfoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
@@ -89,7 +87,6 @@ func (m *TUIModel) renderListView() string {
 	b.WriteString("\n")
 	b.WriteString(help)
 
-	// Show error messages
 	if m.err != nil && time.Since(m.errorTime) < errorToastDuration {
 		errMsg := fmt.Sprintf("Error: %v", m.err)
 		if len(errMsg) > 80 {
@@ -105,7 +102,6 @@ func (m *TUIModel) renderListView() string {
 		m.err = nil
 	}
 
-	// Show success messages
 	if m.successMsg != "" && time.Since(m.successTime) < successToastDuration {
 		b.WriteString("\n" + successStyle.Render(m.successMsg))
 	} else if m.successMsg != "" && time.Since(m.successTime) >= 3*time.Second {
@@ -126,7 +122,6 @@ func (m *TUIModel) renderHeader() string {
 
 	headerText := fmt.Sprintf("Active Clients: %d  Total: %d  Last Update: %s",
 		activeCount, len(m.clients), m.lastUpdate.Format("15:04:05"))
-	// Show dropped server logs if any
 	if m.droppedLogs > 0 {
 		headerText += fmt.Sprintf("  Dropped logs: %d", m.droppedLogs)
 	}
@@ -146,12 +141,10 @@ func (m *TUIModel) renderTable() string {
 	rows = append(rows, header)
 	rows = append(rows, strings.Repeat("─", len(header)))
 
-	// Calculate visible range
 	visibleRows := m.getVisibleRows()
 	startIdx := m.listScroll
 	endIdx := min(startIdx+visibleRows, len(m.clients))
 
-	// Show only visible clients
 	for i := startIdx; i < endIdx; i++ {
 		client := m.clients[i]
 		row := m.formatClientRow(client, i == m.selectedIdx)
@@ -163,7 +156,6 @@ func (m *TUIModel) renderTable() string {
 
 	content := strings.Join(rows, "\n")
 
-	// Add scroll indicator if there are more clients
 	var scrollInfo string
 	if len(m.clients) > visibleRows {
 		totalPages := (len(m.clients) + visibleRows - 1) / visibleRows
@@ -189,11 +181,9 @@ func (m *TUIModel) renderDetailView() string {
 	var b strings.Builder
 	client := m.clientDetail
 
-	// Header
 	b.WriteString(headerStyle.Render(fmt.Sprintf("Client Details: %s", formatID(client.ID))))
 	b.WriteString("\n\n")
 
-	// Basic information
 	b.WriteString(fmt.Sprintf("ID: %s\n", client.ID))
 	b.WriteString(fmt.Sprintf("User: %s\n", client.User))
 	b.WriteString(fmt.Sprintf("Virtual Host: %s\n", client.VirtualHost))
@@ -207,7 +197,6 @@ func (m *TUIModel) renderDetailView() string {
 		formatDuration(time.Since(client.ConnectedAt))))
 	b.WriteString(fmt.Sprintf("Client Banner: %s\n", client.ClientBanner))
 
-	// Client Properties
 	if len(client.ClientProperties) > 0 {
 		b.WriteString("\nClient Properties:\n")
 
@@ -226,7 +215,6 @@ func (m *TUIModel) renderDetailView() string {
 		}
 	}
 
-	// Statistics
 	if client.Stats != nil {
 		stats := client.Stats
 		b.WriteString("\nStatistics:\n")
@@ -237,7 +225,6 @@ func (m *TUIModel) renderDetailView() string {
 		b.WriteString(fmt.Sprintf("  Sent Frames: %s\n", formatNumber(stats.SentFrames)))
 		b.WriteString(fmt.Sprintf("  Total Frames: %s\n", formatNumber(stats.TotalFrames)))
 
-		// Method breakdown
 		if len(stats.Methods) > 0 {
 			b.WriteString("\nMethod Statistics:\n")
 
@@ -270,26 +257,22 @@ func (m *TUIModel) renderDetailView() string {
 	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • p probe • Shift+K shutdown"
 	b.WriteString(helpStyle.Render(helpText))
 
-	// Implement scrolling
 	content := b.String()
 	lines := strings.Split(content, "\n")
 
 	// Calculate available height (subtract some for header/footer margins)
 	availableHeight := max(m.height-4, 10)
 
-	// Limit scroll position
 	maxScroll := max(len(lines)-availableHeight, 0)
 	if m.detailScroll > maxScroll {
 		m.detailScroll = maxScroll
 	}
 
-	// Apply scrolling
 	startLine := m.detailScroll
 	endLine := min(startLine+availableHeight, len(lines))
 
 	scrolledLines := lines[startLine:endLine]
 
-	// Add scroll indicator if content is scrollable
 	result := strings.Join(scrolledLines, "\n")
 	if maxScroll > 0 {
 		scrollInfo := fmt.Sprintf(" [%d/%d]", m.detailScroll+1, maxScroll+1)
@@ -324,7 +307,6 @@ func (m *TUIModel) getVisibleRows() int {
 	headerLines := 3 // header + spacing
 	helpLines := 2   // help + spacing
 
-	// Calculate log pane lines dynamically
 	logPaneLines := m.estimateLogPaneLines()
 
 	marginLines := 4 // various margins and spacing
@@ -350,9 +332,7 @@ func (m *TUIModel) estimateLogPaneLines() int {
 
 	for i := startIdx; i < len(m.logEntries); i++ {
 		entry := m.logEntries[i]
-		// Estimate lines for this entry
 		logText := m.formatLogEntry(entry, false)
-		// Count newlines in formatted log
 		lineCount += strings.Count(logText, "\n") + 1
 	}
 
@@ -366,7 +346,6 @@ func (m *TUIModel) renderProbeView() string {
 	}
 	var b strings.Builder
 
-	// Header
 	headerText := fmt.Sprintf("Probe Logs: %s", formatID(m.probeState.clientID))
 	b.WriteString(headerStyle.Render(headerText))
 	b.WriteString("\n\n")
@@ -381,7 +360,6 @@ func (m *TUIModel) renderProbeView() string {
 	b.WriteString(statusDimStyle.Render(statusText))
 	b.WriteString("\n\n")
 
-	// Render logs
 	if logCount == 0 {
 		b.WriteString("Waiting for probe logs...\n")
 		// Debug: Show probe state details
@@ -398,7 +376,6 @@ func (m *TUIModel) renderProbeView() string {
 	} else {
 		maxDisplayLines := m.getProbeVisibleRows()
 
-		// Use common rendering function
 		result := renderLogsWithWrapping(
 			logCount,
 			maxDisplayLines,
@@ -414,13 +391,11 @@ func (m *TUIModel) renderProbeView() string {
 			},
 		)
 
-		// Write rendered logs
 		for _, logLine := range result.renderedLines {
 			b.WriteString(logLine)
 			b.WriteString("\n")
 		}
 
-		// Add scroll indicator
 		if logCount > len(result.renderedLines) {
 			scrollInfo := fmt.Sprintf(" [%d-%d of %d logs]",
 				result.startIdx+1, result.endIdx, logCount)
@@ -428,7 +403,6 @@ func (m *TUIModel) renderProbeView() string {
 		}
 	}
 
-	// Help text
 	b.WriteString("\n")
 	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • PgUp/PgDn page • SPACE pause • s save"
 	if m.probeState != nil {
@@ -440,13 +414,11 @@ func (m *TUIModel) renderProbeView() string {
 	}
 	b.WriteString(helpStyle.Render(helpText))
 
-	// Show error messages
 	if m.err != nil && time.Since(m.errorTime) < errorToastDuration {
 		errMsg := fmt.Sprintf("Error: %v", m.err)
 		b.WriteString("\n" + errorStyle.Render(errMsg))
 	}
 
-	// Show success messages (short toast)
 	if m.successMsg != "" && time.Since(m.successTime) < successToastDuration {
 		b.WriteString("\n" + successStyle.Render(m.successMsg))
 	}
@@ -471,19 +443,16 @@ func (m *TUIModel) formatProbeLogLine(log probeLogEntry) string {
 		}
 	}
 
-	// Calculate available width for wrapping
 	width := m.width - 2 // -2 for margins
 	if width <= 0 {
 		width = 80 // default width
 	}
 
-	// Combine and wrap the full text
 	fullText := mainText
 	if attrStr != "" {
 		fullText += " " + attrStr
 	}
 
-	// Wrap to screen width
 	lines := wrapText(fullText, width)
 
 	// Apply styling to the attrs portion of the first line and subsequent wrapped lines
@@ -533,7 +502,6 @@ func renderLogsWithWrapping(
 		return renderResult{}
 	}
 
-	// Clamp inputs
 	startIdx := max(scrollPos, 0)
 	if startIdx >= logCount {
 		startIdx = logCount - 1
@@ -574,7 +542,6 @@ func renderLogsWithWrapping(
 			break
 		}
 
-		// Re-format with selection styling if this is the selected entry
 		if i == selectedIdx {
 			logLine = formatFunc(i, true)
 		}
@@ -672,7 +639,6 @@ func wrapText(text string, width int) []string {
 			ch := runes[i]
 			rw := runewidth.RuneWidth(ch)
 
-			// If adding this rune would exceed width, wrap here
 			if lineWidth+rw > width {
 				out = append(out, string(runes[start:i]))
 				start = i
@@ -682,7 +648,6 @@ func wrapText(text string, width int) []string {
 			lineWidth += rw
 		}
 
-		// Flush remainder
 		if start < len(runes) {
 			out = append(out, string(runes[start:]))
 		}
@@ -726,19 +691,16 @@ func (m *TUIModel) formatLogEntry(entry LogEntry, isSelected bool) string {
 
 	attrStr := entry.AttrJSON
 
-	// Calculate available width for wrapping
 	width := m.width - 2 // -2 for margins
 	if width <= 0 {
 		width = 80 // default width
 	}
 
-	// Combine and wrap the full text
 	fullText := mainText
 	if attrStr != "" {
 		fullText += " " + attrStr
 	}
 
-	// Wrap to screen width
 	lines := wrapText(fullText, width)
 
 	// Apply styling to the level and attrs portions
@@ -830,7 +792,6 @@ func (m *TUIModel) adjustScrollForSelection() {
 func (m *TUIModel) renderServerLogsView() string {
 	var b strings.Builder
 
-	// Header
 	headerText := fmt.Sprintf("Server Logs (%d total)", len(m.logEntries))
 	if m.droppedLogs > 0 {
 		headerText += fmt.Sprintf(" • dropped %d", m.droppedLogs)
@@ -845,7 +806,6 @@ func (m *TUIModel) renderServerLogsView() string {
 		logCount := len(m.logEntries)
 		maxDisplayLines := m.getServerLogsVisibleRows()
 
-		// Use common rendering function
 		result := renderLogsWithWrapping(
 			logCount,
 			maxDisplayLines,
@@ -857,13 +817,11 @@ func (m *TUIModel) renderServerLogsView() string {
 			},
 		)
 
-		// Write rendered logs
 		for _, logLine := range result.renderedLines {
 			b.WriteString(logLine)
 			b.WriteString("\n")
 		}
 
-		// Add scroll indicator
 		if logCount > len(result.renderedLines) {
 			scrollInfo := fmt.Sprintf(" [%d-%d of %d logs]",
 				result.startIdx+1, result.endIdx, logCount)
@@ -872,7 +830,6 @@ func (m *TUIModel) renderServerLogsView() string {
 		}
 	}
 
-	// Help text
 	b.WriteString("\n")
 	helpText := "Press ESC/q to go back • ↑↓/kj to scroll • Home/End • PgUp/PgDn page"
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(helpText))
@@ -909,7 +866,6 @@ func (m *TUIModel) renderSaveConfirmView() string {
 		b.WriteString(fmt.Sprintf("Logs to save: %d entries\n\n", len(m.probeState.logs)))
 	}
 
-	// Help text
 	if m.saveState.editing {
 		helpText := "Type to edit path • ESC to stop editing • ENTER to confirm"
 		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(helpText))

--- a/upstream.go
+++ b/upstream.go
@@ -23,7 +23,7 @@ type Upstream struct {
 	channel      map[uint16]*rabbitmq.Channel
 	mu           sync.Mutex
 	logger       *slog.Logger
-	probeLogFunc func(string, ...any) // Function to send probe logs
+	probeLogFunc func(string, ...any)
 	keyPatterns  []string
 	queueAttr    *config.QueueAttributes
 	queueOpts    *config.QueueOptions
@@ -48,7 +48,6 @@ func NewUpstream(conn *rabbitmq.Connection, logger *slog.Logger, conf config.Ups
 		metrics:      metrics,
 		probeLogFunc: probeLogFunc,
 	}
-	// Register for connection close notifications if connection is not nil
 	if conn != nil {
 		conn.NotifyClose(u.closeChan)
 	}
@@ -199,7 +198,6 @@ func (u *Upstream) QueueDeclareArgs(m *amqp091.QueueDeclare) (name string, durab
 		return m.Queue, m.Durable, m.AutoDelete, m.Exclusive, false, rabbitmq.Table(m.Arguments)
 	} else {
 		u.probeLog("t->u overriding queue attributes", "queue", m.Queue, "attributes", *attr)
-		// override the message's attributes with the upstream's configuration
 		durable := m.Durable
 		if attr.Durable != nil {
 			durable = *attr.Durable
@@ -247,17 +245,14 @@ func (u *Upstream) QueueDeclareWithTryPassive(ch *rabbitmq.Channel, m *amqp091.Q
 			// Don't register for emulation if queue already existed
 			return q, nil
 		}
-		// Check if error is NOT_FOUND (404)
 		if amqpErr, ok := err.(*rabbitmq.Error); ok && amqpErr.Code == amqp091.NotFound {
 			u.probeLog("t<-u queue not found, falling back to normal declare", "queue", m.Queue)
 			// Fall through to normal declare
 		} else {
-			// Other errors should be returned
 			return rabbitmq.Queue{}, fmt.Errorf("passive declare failed: %w", err)
 		}
 	}
 
-	// Normal declare with configured attributes
 	name, durable, autoDelete, exclusive, noWait, args := u.QueueDeclareArgs(m)
 	u.probeLog("t->u declaring queue", "queue", name, "durable", durable, "auto_delete", autoDelete, "exclusive", exclusive, "arguments", args)
 	q, err := ch.QueueDeclare(name, durable, autoDelete, exclusive, noWait, args)
@@ -265,7 +260,6 @@ func (u *Upstream) QueueDeclareWithTryPassive(ch *rabbitmq.Channel, m *amqp091.Q
 		return q, fmt.Errorf("failed to declare queue: %w", err)
 	}
 
-	// Check if we should emulate auto_delete for this queue
 	if !queueExisted && u.shouldEmulateAutoDelete(m) {
 		u.probeLog("t->u registering queue for emulated auto_delete", "queue", q.Name)
 		u.RegisterEmulatedAutoDeleteQueue(q.Name)
@@ -276,12 +270,10 @@ func (u *Upstream) QueueDeclareWithTryPassive(ch *rabbitmq.Channel, m *amqp091.Q
 
 // shouldEmulateAutoDelete checks if auto_delete emulation should be enabled for this queue
 func (u *Upstream) shouldEmulateAutoDelete(m *amqp091.QueueDeclare) bool {
-	// Check if emulation is enabled in config
 	if u.queueOpts == nil || !u.queueOpts.EmulateAutoDelete {
 		return false
 	}
 
-	// Check if client requested auto_delete=true
 	if !m.AutoDelete {
 		return false
 	}


### PR DESCRIPTION
## What

Remove inline comments that merely narrate the adjacent code (what/how) across the production code, keeping comments that explain **why**: design rationale (e.g. "avoid concurrent writes", "prevent reconnection storms"), protocol semantics, magic-number explanations, lock requirements, and non-obvious behavior. Godoc comments on declarations are kept per Go convention.

Also fixes incidental comment bugs found along the way:
- `// Server represents a trabbits server instance` was attached to `proxyEntry`; moved to `Server`
- Godoc names mismatched their functions (`recordPublish` → `RecordPublish`, `lookupClientTag` → `LookupClientTag`, `manageProxyProbe` → `manageClientProbe`)
- Stale "Prometheus metrics" wording in stats.go (metrics are now OpenTelemetry)

## Why

Comments duplicating the code add noise and rot as the code changes; the remaining comments now carry information the code cannot express.

Note: test files are left untouched — their comments mostly describe scenario intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)